### PR TITLE
Fix public profile to return hackathons, history, and badges

### DIFF
--- a/model/user.py
+++ b/model/user.py
@@ -149,16 +149,16 @@ class User:
             if hasattr(self, field) and getattr(self, field) is not None:
                 public_data[field] = getattr(self, field)
 
+        # Fields that need special handling (not simple attribute lookups)
+        special_fields = {"hackathon_history", "what", "how", "badges"}
+
         # Include privacy-controlled fields only if user made them public
         for field in privacy_fields:
             if field in pii_fields:
                 continue  # Never share PII fields
 
-            # hackathon_history controls the hackathons list, not a direct attribute
-            if field == "hackathon_history":
-                if privacy_settings.get(field, False) == "public":
-                    public_data["hackathons"] = self.serialize_hackathons()
-                continue
+            if field in special_fields:
+                continue  # Handled below
 
             if hasattr(self, field) and privacy_settings.get(field, False) == "public":
                 field_value = getattr(self, field)
@@ -166,17 +166,21 @@ class User:
                 if field_value is not None and field_value != "":
                     public_data[field] = field_value
 
-        # Include history (what/how feedback data) if either what or how is public
-        if privacy_settings.get("what", False) == "public" or privacy_settings.get("how", False) == "public":
-            history = {}
-            if privacy_settings.get("what", False) == "public" and hasattr(self, 'history') and 'what' in self.history:
-                history["what"] = self.history["what"]
-            if privacy_settings.get("how", False) == "public" and hasattr(self, 'history') and 'how' in self.history:
-                history["how"] = self.history["how"]
-            if history:
-                public_data["history"] = history
+        # Hackathons: controlled by hackathon_history privacy field
+        if privacy_settings.get("hackathon_history", False) == "public":
+            public_data["hackathons"] = self.serialize_hackathons()
 
-        # Include badges if public (badges are stored as a list, not a simple field)
+        # Feedback history: what and how are independent privacy fields
+        # Nested under "history" to match the structure the frontend expects
+        history = {}
+        if privacy_settings.get("what", False) == "public" and hasattr(self, 'history') and 'what' in self.history:
+            history["what"] = self.history["what"]
+        if privacy_settings.get("how", False) == "public" and hasattr(self, 'history') and 'how' in self.history:
+            history["how"] = self.history["how"]
+        if history:
+            public_data["history"] = history
+
+        # Badges: stored as a list, not a simple field value
         if privacy_settings.get("badges", False) == "public" and hasattr(self, 'badges') and self.badges:
             public_data["badges"] = self.badges
 

--- a/model/user.py
+++ b/model/user.py
@@ -1,5 +1,5 @@
 metadata_list = ["role", "expertise", "education", "company", "why", "shirt_size", "github", "volunteering", "linkedin_url", "instagram_url", "propel_id"]
-privacy_fields = ["github", "role", "company", "badges", "expertise", "education", "why", "linkedin_url", "instagram_url", "what", "how", "feedback"]
+privacy_fields = ["github", "role", "company", "badges", "expertise", "education", "why", "linkedin_url", "instagram_url", "what", "how", "feedback", "hackathon_history"]
 
 # Fields that should NEVER be shared publicly regardless of privacy settings
 pii_fields = ["email_address", "last_login", "propel_id", "volunteering"]
@@ -154,11 +154,31 @@ class User:
             if field in pii_fields:
                 continue  # Never share PII fields
 
+            # hackathon_history controls the hackathons list, not a direct attribute
+            if field == "hackathon_history":
+                if privacy_settings.get(field, False) == "public":
+                    public_data["hackathons"] = self.serialize_hackathons()
+                continue
+
             if hasattr(self, field) and privacy_settings.get(field, False) == "public":
                 field_value = getattr(self, field)
 
                 if field_value is not None and field_value != "":
                     public_data[field] = field_value
+
+        # Include history (what/how feedback data) if either what or how is public
+        if privacy_settings.get("what", False) == "public" or privacy_settings.get("how", False) == "public":
+            history = {}
+            if privacy_settings.get("what", False) == "public" and hasattr(self, 'history') and 'what' in self.history:
+                history["what"] = self.history["what"]
+            if privacy_settings.get("how", False) == "public" and hasattr(self, 'history') and 'how' in self.history:
+                history["how"] = self.history["how"]
+            if history:
+                public_data["history"] = history
+
+        # Include badges if public (badges are stored as a list, not a simple field)
+        if privacy_settings.get("badges", False) == "public" and hasattr(self, 'badges') and self.badges:
+            public_data["badges"] = self.badges
 
         # Include privacy settings themselves for the frontend to know what's public
         public_data["privacy_settings"] = privacy_settings


### PR DESCRIPTION
## Summary
- `get_public_profile_data()` only iterated over `privacy_fields` for simple attribute lookups, so **hackathons**, **feedback history** (what/how), and **badges** were never returned in the public profile API response — even when the user set them to public
- Add `hackathon_history` to `privacy_fields` so it's recognized as a valid privacy-controlled field
- Return serialized hackathons list when `hackathon_history` is set to public
- Return `history.what` / `history.how` independently based on their respective privacy settings
- Return badges list when `badges` is set to public (note: badges population from Firestore is still TODO — this ensures the plumbing is ready)

## Context
Companion to frontend PR: https://github.com/opportunity-hack/frontend-ohack.dev/pull/271

## Test plan
- [ ] Set hackathon_history to "public" via privacy settings, verify `/api/users/<id>/profile/public` returns `hackathons` array
- [ ] Set hackathon_history to "private", verify hackathons are omitted from response
- [ ] Set what/how to "public", verify `history` object appears with correct sub-keys
- [ ] Set badges to "public", verify badges array is included (when badges are populated)
- [ ] Verify no PII fields leak regardless of privacy settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)