### PR TITLE
Fix PII leak in public volunteer endpoints

### DIFF
--- a/common/utils/firebase.py
+++ b/common/utils/firebase.py
@@ -28,6 +28,27 @@ logger.setLevel(logging.DEBUG)
 MAX_PRAISES_ABOUT_USER = 50
 MAX_PRAISES = 20
 
+# Fields that must not appear in responses from the PUBLIC (unauthenticated)
+# volunteer endpoints. Any *new* field added to volunteer documents is public
+# by default; add sensitive keys here. Admin endpoints bypass this filter.
+PUBLIC_VOLUNTEER_DENYLIST = frozenset({
+    # direct PII / sensitive attendee data
+    "email", "ageRange", "shirtSize", "dietaryRestrictions",
+    "phone", "phoneNumber",
+    # identifiers / audit
+    "user_id", "slack_user_id",
+    "created_by", "updated_by",
+    "created_timestamp", "updated_timestamp", "timestamp",
+    # internal messaging state
+    "sent_emails",
+    # free-form fields that may contain PII
+    "additionalInfo", "whyJudge", "otherBackground",
+    # check-in audit (admin-only attendance data)
+    "checkedIn", "checkedInBy", "checkedInAt",
+    # admin-only enrichment
+    "certificates",
+})
+
 def get_db():
     if safe_get_env_var("ENVIRONMENT") == "test":
         return mockfirestore
@@ -1255,9 +1276,13 @@ def get_volunteer_from_db_by_event(event_id: str, volunteer_type: str, admin: bo
         # Stream the documents and convert to list of dicts also with their id from the database
         volunteers = [ {**doc.to_dict(), "id": doc.id} for doc in query.stream() ]     
 
-        # With this dict, remove the "email" and "ageRange" and "shirtSize" and "dietaryRestrictions" field if it exists for each record without using pop
+        # Strip fields that must not be exposed on the public (unauthenticated)
+        # endpoints. See PUBLIC_VOLUNTEER_DENYLIST above.
         if not admin:
-            volunteers = [{k: v for k, v in volunteer.items() if k != "email" and k != "ageRange" and k != "shirtSize" and k != "dietaryRestrictions"} for volunteer in volunteers]
+            volunteers = [
+                {k: v for k, v in volunteer.items() if k not in PUBLIC_VOLUNTEER_DENYLIST}
+                for volunteer in volunteers
+            ]
 
         if not volunteers:
             logger.info(f"No {volunteer_type}s found for event_id={event_id}")


### PR DESCRIPTION
## Summary
- Public `GET /api/messages/hackathon/<event_id>/<volunteer_type>` currently leaks PII and internal metadata: `sent_emails` (Resend email history), `updated_by`, `created_by`, `user_id`, `slack_user_id`, `additionalInfo`, check-in audit fields (`checkedIn`, `checkedInBy`, `checkedInAt`), free-form PII-risk fields (`whyJudge`, `otherBackground`), and internal timestamps.
- Replace the inline 4-field filter in `get_volunteer_from_db_by_event` with a module-level `PUBLIC_VOLUNTEER_DENYLIST` frozenset and drop every denylisted key when `admin=False`. Admin endpoints (`/admin/hackathon/...`) are unchanged.
- Companion frontend PR switches three admin pages (admin/check-in, JudgingRound1, JudgingRound2) that were incorrectly calling the public endpoint over to `/admin/hackathon/...` so they continue to receive the full record.

## Test plan
- [ ] `curl https://api.ohack.dev/api/messages/hackathon/<event>/volunteer | jq '.data[0] | keys'` — confirm none of: `email`, `sent_emails`, `updated_by`, `created_by`, `user_id`, `slack_user_id`, `additionalInfo`, `checkedInBy`, `created_timestamp`, `updated_timestamp` appear.
- [ ] With admin token: `curl -H "Authorization: Bearer $TOKEN" -H "X-Org-Id: $ORG" https://api.ohack.dev/api/messages/admin/hackathon/<event>/volunteer | jq '.data[0] | keys'` — confirm `email` etc. are still present.
- [ ] Repeat for `/mentor`, `/judge`, `/hacker`, `/sponsor` types.
- [ ] Smoke test `/hack/<event>/census` page — grids still render.

## Follow-ups
- Any new field added to a volunteer document is public by default under a denylist. When adding fields, add sensitive keys to `PUBLIC_VOLUNTEER_DENYLIST`. Consider migrating to an allowlist if schema drift becomes a concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)