### PR TITLE
Fix @oauth2 Slack mention for non-Slack help signups

### DIFF
--- a/api/messages/messages_service.py
+++ b/api/messages/messages_service.py
@@ -1,10 +1,12 @@
 from common.utils import safe_get_env_var
 from common.utils.slack import send_slack_audit, send_slack, invite_user_to_channel
 from common.utils.firebase import get_github_contributions_for_user
+from common.utils.oauth_providers import is_slack_user_id, extract_slack_user_id
 from api.messages.message import Message
 from google.cloud.exceptions import NotFound
 
 from services.users_service import get_propel_user_details_by_id, get_slack_user_from_propel_user_id, get_user_from_slack_id, save_user
+from services.email_service import send_project_help_slack_invite_email
 import json
 import uuid
 from datetime import datetime
@@ -131,9 +133,22 @@ def save_helping_status_old(propel_user_id, json):
 
     send_slack_audit(action="helping", message=user_id, payload=to_add)
 
+    # Determine how to identify this user in the Slack post.
+    # Slack logins get a real <@Uxxx> mention + auto-invite to the project channel.
+    # Non-Slack logins (Google, etc.) fall back to their display name so we don't
+    # render a broken "@oauth2" mention, and get a follow-up email asking them to
+    # join the Slack workspace.
+    if is_slack_user_id(user_id):
+        slack_user_id = extract_slack_user_id(user_id)
+        mention = f"<@{slack_user_id}>"
+        is_slack_login = True
+        logger.info(f"save_helping_status_old: Slack login, mention={slack_user_id}")
+    else:
+        slack_user_id = None
+        mention = (user_obj.name or user_obj.nickname or user_obj.email_address or "A volunteer").strip()
+        is_slack_login = False
+        logger.info(f"save_helping_status_old: non-Slack login ({user_id}), mention={mention}")
 
-    slack_user_id = user_id.split("-")[1]  # Example user_id = oauth2|slack|T1Q7116BH-U041117EYTQ
-    slack_message = f"<@{slack_user_id}>"
     problem_statement_title = ps_dict["title"]
 
     if "slack_channel" in ps_dict:
@@ -146,15 +161,35 @@ def save_helping_status_old(propel_user_id, json):
             url = f"for nonprofit https://ohack.dev/nonprofit/{npo_id} on project https://ohack.dev/project/{problem_statement_id}"
 
         if "helping" == helping_status:
-            slack_message = f"{slack_message} is helping as a *{mentor_or_hacker}* on *{problem_statement_title}* {url}"
+            slack_message = f"{mention} is helping as a *{mentor_or_hacker}* on *{problem_statement_title}* {url}"
         else:
-            slack_message = f"{slack_message} is _no longer able to help_ on *{problem_statement_title}* {url}"
+            slack_message = f"{mention} is _no longer able to help_ on *{problem_statement_title}* {url}"
 
-        invite_user_to_channel(user_id=slack_user_id,
-                            channel_name=problem_statement_slack_channel)
+        if is_slack_login and slack_user_id:
+            try:
+                invite_user_to_channel(user_id=slack_user_id,
+                                    channel_name=problem_statement_slack_channel)
+            except Exception as e:
+                logger.warning(f"invite_user_to_channel failed for {slack_user_id}: {e}")
 
         send_slack(message=slack_message,
                     channel=problem_statement_slack_channel)
+
+    # For non-Slack users who are signing up to help, email them with a Slack join CTA
+    # so their project team can actually reach them. Swallow errors so a Resend
+    # outage never breaks the help toggle.
+    if not is_slack_login and helping_status == "helping" and user_obj.email_address:
+        try:
+            send_project_help_slack_invite_email(
+                name=user_obj.name or user_obj.nickname,
+                email=user_obj.email_address,
+                problem_statement_title=ps_dict.get("title"),
+                mentor_or_hacker=mentor_or_hacker,
+                npo_id=npo_id or None,
+                problem_statement_id=problem_statement_id,
+            )
+        except Exception as e:
+            logger.warning(f"send_project_help_slack_invite_email failed for {user_obj.email_address}: {e}")
 
     return Message(
         "Updated helping status"

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -182,6 +182,85 @@ def send_welcome_email(name, email):
     return True
 
 
+def send_project_help_slack_invite_email(name, email, problem_statement_title, mentor_or_hacker, npo_id=None, problem_statement_id=None):
+    """Email a volunteer who signed up to help via a non-Slack login, asking them to join the OHack Slack workspace."""
+    resend.api_key = os.getenv("RESEND_WELCOME_EMAIL_KEY")
+
+    if not email:
+        logger.warning("send_project_help_slack_invite_email skipped: no email address")
+        return False
+
+    if name is None or name == "" or name == "Unassigned" or name.isspace():
+        name = "OHack Friend"
+
+    role_label = "mentor" if mentor_or_hacker == "mentor" else "hacker"
+    project_title = problem_statement_title or "an Opportunity Hack project"
+    utm_content = f"help_signup_{role_label}"
+
+    slack_url = add_utm("https://slack.ohack.dev", content=utm_content)
+
+    project_link_html = ""
+    if problem_statement_id:
+        project_url = add_utm(f"https://ohack.dev/project/{problem_statement_id}", content=utm_content)
+        project_link_html += f'<li><a href="{project_url}">View the project</a></li>'
+    if npo_id:
+        npo_url = add_utm(f"https://ohack.dev/nonprofit/{npo_id}", content=utm_content)
+        project_link_html += f'<li><a href="{npo_url}">View the nonprofit</a></li>'
+    if project_link_html:
+        project_link_html = f"<ul>{project_link_html}</ul>"
+
+    subject = "Thanks for volunteering! Next step: join us on Slack"
+
+    html_content = f"""
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Thanks for volunteering with Opportunity Hack</title>
+    </head>
+    <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+        <h1 style="color: #0088FE;">Thanks {name}!</h1>
+
+        <p>We saw that you signed up to help as a <strong>{role_label}</strong> on <strong>{project_title}</strong>. That's awesome — thank you!</p>
+
+        {project_link_html}
+
+        <h2 style="color: #0088FE;">One more step: join us on Slack</h2>
+
+        <p>It looks like you signed in with Google instead of Slack. All of our project coordination, questions, and day-to-day collaboration with the nonprofit and other volunteers happens in our Slack workspace.</p>
+
+        <p>Please join us so your project team can reach you:</p>
+
+        <p style="text-align: center; margin: 28px 0;">
+            <a href="{slack_url}" style="background-color: #0088FE; color: #ffffff; padding: 14px 28px; border-radius: 6px; text-decoration: none; font-weight: bold; display: inline-block;">Join the Opportunity Hack Slack</a>
+        </p>
+
+        <p>Once you're in, say hi in <code>#general</code> and a team member will help you find the right project channel.</p>
+
+        <p>Questions? Just reply to this email — it goes straight to questions@ohack.org.</p>
+
+        <p>Thanks again for volunteering,<br>The Opportunity Hack Team</p>
+    </body>
+    </html>
+    """
+
+    params = {
+        "from": "Opportunity Hack <welcome@notifs.ohack.org>",
+        "to": f"{name} <{email}>",
+        "cc": "questions@ohack.org",
+        "reply_to": "questions@ohack.org",
+        "subject": subject,
+        "html": html_content,
+    }
+
+    logger.info(f"Sending project-help Slack invite email to {email}")
+    resend_email = resend.Emails.SendParams(params)
+    resend.Emails.send(resend_email)
+    logger.info(f"Sent project-help Slack invite email to {email}")
+    return True
+
+
 def send_welcome_emails():
     from db.db import get_db
     logger.info("Sending welcome emails")


### PR DESCRIPTION
## Summary
- Volunteers who sign up to help on a project via a non-Slack login (e.g. Google) showed up in the Slack channel as "@oauth2" instead of a real name, because `save_helping_status_old` was splitting the OAuth user ID on `-` and blindly wrapping it in `<@...>`. For Gmail IDs like `oauth2|google-oauth2|<sub>`, Slack interpreted the `|` as mention-label syntax and rendered the literal text "@oauth2".
- Now uses `is_slack_user_id` / `extract_slack_user_id` from `common/utils/oauth_providers.py`. Slack users keep today's behavior (`<@Uxxx>` mention + auto-invite to the project channel). Non-Slack users fall back to `user.name` as plain text in the Slack post, and the channel auto-invite is skipped (it would 400 on an invalid Slack ID).
- On a non-Slack `helping` signup, sends a follow-up email via Resend thanking the volunteer and asking them to join the workspace at https://slack.ohack.dev so the project team can actually reach them. Failures are swallowed so a Resend outage never breaks the help toggle.

## Files changed
- `api/messages/messages_service.py` — `save_helping_status_old` OAuth branching
- `services/email_service.py` — new `send_project_help_slack_invite_email`

## Why not migrate the endpoint to the newer `save_helping_status`?
`services/problem_statements_service.py:save_helping_status` already branches on `is_slack_user_id`, but it silently skips the Slack post entirely for non-Slack users. Switching endpoints would regress project-team visibility. Smaller-blast-radius fix here; consolidation is follow-up work.

## Test plan
- [ ] Log in with a Slack account, toggle help on a project → Slack post still uses `<@Uxxx>` mention and user is invited to the project channel. No email sent.
- [ ] Log in with a Google account, toggle help on a project → Slack post uses the user's real name in plain text (no broken `@oauth2`); user receives the "Join Slack" email; no `invite_user_to_channel` call / no Slack 400 in logs.
- [ ] Toggle back to "not helping" for both user types → Slack post says "_no longer able to help_"; no email on not-helping.
- [ ] Simulate a Resend failure (invalid `RESEND_WELCOME_EMAIL_KEY`) and repeat the Google flow → Slack post still goes out; endpoint still returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)