### PR TITLE
[Teams] Add demo_video_url field + hacker self-serve endpoint

### DIFF
--- a/api/teams/teams_service.py
+++ b/api/teams/teams_service.py
@@ -268,11 +268,23 @@ def edit_team(json):
         "location": "location",
         "admin_notes": "admin_notes",
         "devpost_link": "devpost_link",
+        "demo_video_url": "demo_video_url",
     }
-    
+
+    # Normalize demo_video_url: trim, cap at 500 chars, empty string => clear
+    if "demo_video_url" in json:
+        raw = json.get("demo_video_url")
+        if isinstance(raw, str):
+            trimmed = raw.strip()[:500]
+            json["demo_video_url"] = trimmed if trimmed else None
+
     # If this is the first time setting devpost_link, set devpost_link_submitted date
     if "devpost_link" in json and "devpost_link" not in team_data:
         update_data["devpost_link_submitted"] = datetime.now().isoformat()
+
+    # If this is the first time setting demo_video_url, stamp demo_video_url_submitted
+    if json.get("demo_video_url") and not team_data.get("demo_video_url"):
+        update_data["demo_video_url_submitted"] = datetime.now().isoformat()
 
     for db_field, json_field in field_mappings.items():
         if json_field in json:

--- a/api/teams/teams_views.py
+++ b/api/teams/teams_views.py
@@ -87,10 +87,28 @@ def add_devpost_to_team_api(teamid):
         logger.info(f"Devpost link: {devpost_link}")
         if not devpost_link:
             return {"error": "Devpost link is required"}, 400
-        
+
         return edit_team({"id": teamid, "devpost_link": devpost_link})
-    
+
     logger.error("Could not obtain user details for POST /team/<teamid>/devpost")
+    return {"error": "Unauthorized"}, 401
+
+@bp.route("/<teamid>/demo-video", methods=["POST"])
+@auth.require_user
+def add_demo_video_to_team_api(teamid):
+    """
+    Add or clear a demo video URL for a team.
+    Requires user to be authenticated (team self-serve, mirrors devpost endpoint).
+    Pass demo_video_url as empty string or null to clear.
+    """
+    logger.info(f"POST /team/{teamid}/demo-video called")
+    if auth_user and auth_user.user_id:
+        body = request.get_json() or {}
+        demo_video_url = body.get("demo_video_url", "")
+        # Allow empty string to clear the field; edit_team normalizes to None
+        return edit_team({"id": teamid, "demo_video_url": demo_video_url})
+
+    logger.error("Could not obtain user details for POST /team/<teamid>/demo-video")
     return {"error": "Unauthorized"}, 401
 
 @bp.route("/<teamid>/member", methods=["POST"])


### PR DESCRIPTION
## What does the PR do?

Adds a per-team `demo_video_url` (string) so each team can attach a single demo video link (YouTube, Vimeo, Loom, or Google Drive) that the public event and results pages will render in the team card. Mirrors the existing `devpost_link` shape, including a companion `demo_video_url_submitted` ISO timestamp stamped on first set.

**Changes:**
- `edit_team()` field allowlist now accepts `demo_video_url`. Value is trimmed, capped at 500 chars, and empty strings are coerced to `null` so admins can clear the field by submitting an empty input.
- New `POST /api/team/<teamid>/demo-video` mirrors the existing `/devpost` endpoint so a logged-in team member can self-serve their team's demo video (same auth model as devpost — no admin permission required). Admin edits continue to flow through `PATCH /api/team/edit` (`volunteer.admin`).
- No new collection, no schema migration — additive field on the existing `teams` document.

### Type of change

- [ ] Breaking Change
- [ ] Bug Fix
- [x] New Feature

## Linked Issue

None.

## Make sure you have

- [x] Pulled from the default branch
- [x] Documented your changes
- [ ] Linked the Issue
- [ ] Appointed a reviewer (if any)

## Frontend companion

Frontend consumers (event-page team cards, winner cards, `/manageteam` self-serve form, `/admin/teams` Demo Video column + filter chips) are on a separate branch in `opportunity-hack/frontend-ohack.dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)