### PR TITLE
[Teams] Project-completion checklist + enriched team member display

### DIFF
--- a/api/teams/teams_service.py
+++ b/api/teams/teams_service.py
@@ -20,6 +20,31 @@ from common.utils.slack import add_bot_to_channel
 
 logger = logging.getLogger("myapp")
 
+# Slack user IDs for OHack admins who are auto-invited to every team channel
+# and CCed on completion broadcasts. Single source of truth for both call sites.
+TEAM_COMPLETION_SLACK_ADMINS = [
+    "UCQKX6LPR",
+    "U035023T81Z",
+    "UC31XTRT5",
+    "UC2JW3T3K",
+    "UPD90QV17",
+    "UEP2U69AA",
+]
+
+# Canonical 8-item Definition of Done. Must stay in lockstep with the frontend
+# COMPLETION_ITEMS array in src/components/Teams/TeamCompletionChecklist.js.
+COMPLETION_ITEMS = [
+    {"slug": "deployed", "label": "Deployed", "blurb": "Code is live in production (AWS, fly.io, GCP)."},
+    {"slug": "nonprofit_signoff", "label": "Nonprofit Signoff", "blurb": "Your nonprofit partner agrees the software meets their needs."},
+    {"slug": "login_details", "label": "Login Details for Testing", "blurb": "Test credentials shared securely (changeable later)."},
+    {"slug": "code_updated", "label": "Code Updated", "blurb": "All code, README, and docs in the designated GitHub repo."},
+    {"slug": "tasks_closed", "label": "Tasks Closed", "blurb": "GitHub issues/tasks closed or addressed."},
+    {"slug": "sensitive_info_security", "label": "Sensitive Info Secured", "blurb": "No secrets in the repo; shared securely elsewhere."},
+    {"slug": "documentation", "label": "Documentation", "blurb": "How to use, deploy, update, and configure."},
+    {"slug": "open_source", "label": "Open-Sourced (MIT)", "blurb": "Repo is public under MIT."},
+]
+COMPLETION_ITEM_SLUGS = {item["slug"]: item for item in COMPLETION_ITEMS}
+
 def add_team_member(team_id, user_id):
     """
     Admin function to add a member to a team
@@ -423,8 +448,7 @@ Let's make a difference! :muscle: :heart:
         
     
     # Add Slack admins
-    slack_admins = ["UCQKX6LPR", "U035023T81Z", "UC31XTRT5", "UC2JW3T3K", "UPD90QV17", "UEP2U69AA"]
-    for admin in slack_admins:
+    for admin in TEAM_COMPLETION_SLACK_ADMINS:
         logger.info("Inviting admin %s to slack channel %s", admin, slack_channel)
         invite_user_to_channel(admin, slack_channel)
 
@@ -989,3 +1013,193 @@ def send_team_message(admin_user, teamid, json):
         "success": True,
         "team_id": teamid
     }
+
+
+def user_is_on_team(propel_user_id, team_id):
+    """
+    Returns True if the caller (identified by their PropelAuth UUID) is one of
+    the team's users[]. Translates propel_id -> OAuth user_id via
+    get_propel_user_details_by_id (same pattern as get_my_teams_by_event_id),
+    then walks team.users[] DocumentReferences and compares each user doc's
+    `user_id` field (or its `propel_id` field as a fallback).
+    """
+    if not propel_user_id or not team_id:
+        return False
+    db = get_db()
+    team_doc = db.collection("teams").document(team_id).get()
+    if not team_doc.exists:
+        return False
+
+    try:
+        details = get_propel_user_details_by_id(propel_user_id) or ()
+        caller_oauth_user_id = details[1] if len(details) > 1 else None
+    except Exception as e:
+        logger.warning("user_is_on_team: get_propel_user_details_by_id failed: %s", e)
+        caller_oauth_user_id = None
+
+    team_data = team_doc.to_dict() or {}
+    for ref in team_data.get("users", []):
+        try:
+            snap = ref.get() if hasattr(ref, "get") else db.collection("users").document(ref).get()
+            if not snap.exists:
+                continue
+            user_data = snap.to_dict() or {}
+            stored_user_id = user_data.get("user_id")
+            stored_propel_id = user_data.get("propel_id")
+            if caller_oauth_user_id and stored_user_id and stored_user_id == caller_oauth_user_id:
+                return True
+            if stored_propel_id and stored_propel_id == propel_user_id:
+                return True
+        except Exception as e:
+            logger.warning("user_is_on_team: failed to resolve a user ref on team %s: %s", team_id, e)
+            continue
+    return False
+
+
+def _completion_done_count(checklist):
+    if not isinstance(checklist, dict):
+        return 0
+    return sum(1 for slug in COMPLETION_ITEM_SLUGS if checklist.get(slug, {}).get("done"))
+
+
+def _project_link(team_data, team_id):
+    event_id = team_data.get("hackathon_event_id") or ""
+    if event_id:
+        return f"https://ohack.dev/hack/{event_id}/team/{team_id}"
+    return f"https://ohack.dev/hack/team/{team_id}"
+
+
+def _completer_name(propel_user_id):
+    try:
+        details = get_propel_user_details_by_id(propel_user_id) or {}
+        return details.get("firstName") or details.get("email") or "A teammate"
+    except Exception:
+        return "A teammate"
+
+
+def toggle_completion_item(propel_user_id, team_id, item_slug):
+    """
+    Mark a single Definition-of-Done item complete for a team. Sends a Slack
+    message to the team's channel. Idempotent in the strict sense: once an item
+    is `done=True`, this returns 409 (no double-Slack, no unchecking).
+    """
+    if item_slug not in COMPLETION_ITEM_SLUGS:
+        return {"error": f"Unknown checklist item: {item_slug}"}, 400
+
+    if not user_is_on_team(propel_user_id, team_id):
+        return {"error": "You must be on this team to update its completion checklist."}, 403
+
+    db = get_db()
+    team_doc = db.collection("teams").document(team_id)
+    snap = team_doc.get()
+    if not snap.exists:
+        return {"error": "Team not found"}, 404
+    team_data = snap.to_dict() or {}
+    checklist = dict(team_data.get("completion_checklist") or {})
+    if checklist.get(item_slug, {}).get("done"):
+        return {"error": "Already complete"}, 409
+
+    name = _completer_name(propel_user_id)
+    now_iso = datetime.now().isoformat()
+    checklist[item_slug] = {
+        "done": True,
+        "completed_at": now_iso,
+        "completed_by_propel_id": propel_user_id,
+        "completed_by_name": name,
+    }
+    done_n = _completion_done_count(checklist)
+    total_n = len(COMPLETION_ITEMS)
+    new_status = "complete" if done_n == total_n else "in_progress"
+
+    update = {
+        "completion_checklist": checklist,
+        "completion_status": new_status,
+    }
+    team_doc.set(update, merge=True)
+
+    item = COMPLETION_ITEM_SLUGS[item_slug]
+    slack_channel = team_data.get("slack_channel")
+    if slack_channel:
+        msg = (
+            f":white_check_mark: *{name}* checked off *{item['label']}* "
+            f"({done_n}/{total_n} complete!)\n"
+            f"{item['blurb']}\n"
+            f"See the full Definition of Done → https://ohack.dev/about/completion"
+        )
+        try:
+            send_slack(message=msg, channel=slack_channel)
+        except Exception as e:
+            logger.error("toggle_completion_item: send_slack failed for team %s: %s", team_id, e)
+
+    send_slack_audit(
+        action="completion_toggle",
+        message=f"Team {team_id} item {item_slug} marked done by {name} ({done_n}/{total_n})",
+        payload={"team_id": team_id, "item": item_slug, "by": propel_user_id},
+    )
+    clear_cache()
+
+    fresh = team_doc.get().to_dict() or {}
+    fresh["id"] = team_id
+    return {"success": True, "team": fresh, "done": done_n, "total": total_n}, 200
+
+
+def mark_team_complete(propel_user_id, team_id):
+    """
+    Finalize a team's project. Requires all 8 checklist items to be done. Posts
+    a celebration message to the team's Slack channel CCing the OHack admins.
+    Idempotent: returns 409 if already complete.
+    """
+    if not user_is_on_team(propel_user_id, team_id):
+        return {"error": "You must be on this team to mark it complete."}, 403
+
+    db = get_db()
+    team_doc = db.collection("teams").document(team_id)
+    snap = team_doc.get()
+    if not snap.exists:
+        return {"error": "Team not found"}, 404
+    team_data = snap.to_dict() or {}
+
+    if team_data.get("completion_status") == "complete":
+        return {"error": "Project already marked complete"}, 409
+
+    checklist = team_data.get("completion_checklist") or {}
+    missing = [s for s in COMPLETION_ITEM_SLUGS if not checklist.get(s, {}).get("done")]
+    if missing:
+        return {"error": "Cannot mark complete: items remaining", "missing": missing}, 409
+
+    name = _completer_name(propel_user_id)
+    now_iso = datetime.now().isoformat()
+    team_doc.set({
+        "completion_status": "complete",
+        "completion_completed_at": now_iso,
+        "completion_completed_by_propel_id": propel_user_id,
+        "completion_completed_by_name": name,
+    }, merge=True)
+
+    slack_channel = team_data.get("slack_channel")
+    team_name = team_data.get("name", "Your team")
+    project_link = _project_link(team_data, team_id)
+    admin_mentions = " ".join(f"<@{uid}>" for uid in TEAM_COMPLETION_SLACK_ADMINS)
+    msg = (
+        f":tada: :rocket: :tada:  *{team_name} marked their project COMPLETE!*\n"
+        f"Congratulations team — you shipped it. 🏆\n\n"
+        f"cc {admin_mentions}\n\n"
+        f"Project link: {project_link}\n"
+        f"See examples of completed projects: https://ohack.dev/about/success-stories"
+    )
+    if slack_channel:
+        try:
+            send_slack(message=msg, channel=slack_channel)
+        except Exception as e:
+            logger.error("mark_team_complete: send_slack failed for team %s: %s", team_id, e)
+
+    send_slack_audit(
+        action="completion_complete",
+        message=f"Team {team_id} ({team_name}) marked PROJECT COMPLETE by {name}",
+        payload={"team_id": team_id, "by": propel_user_id},
+    )
+    clear_cache()
+
+    fresh = team_doc.get().to_dict() or {}
+    fresh["id"] = team_id
+    return {"success": True, "team": fresh}, 200

--- a/api/teams/teams_views.py
+++ b/api/teams/teams_views.py
@@ -14,7 +14,9 @@ from api.teams.teams_service import (
     remove_team,
     get_teams_by_hackathon_id,
     get_my_teams_by_event_id,
-    send_team_message
+    send_team_message,
+    toggle_completion_item,
+    mark_team_complete,
 )
 
 logger = logging.getLogger(__name__)
@@ -110,6 +112,39 @@ def add_demo_video_to_team_api(teamid):
 
     logger.error("Could not obtain user details for POST /team/<teamid>/demo-video")
     return {"error": "Unauthorized"}, 401
+
+@bp.route("/<teamid>/completion/toggle", methods=["POST"])
+@auth.require_user
+def toggle_completion_item_api(teamid):
+    """
+    Mark a single Definition-of-Done item complete on a team. Self-serve for
+    team members. Posts a Slack message into the team's channel. Re-toggling an
+    already-done item returns 409 (no unchecking, no double-Slack).
+    Body: { "item": "<slug>" }
+    """
+    logger.info(f"POST /team/{teamid}/completion/toggle called")
+    if not (auth_user and auth_user.user_id):
+        return {"error": "Unauthorized"}, 401
+    body = request.get_json() or {}
+    item_slug = body.get("item")
+    if not item_slug:
+        return {"error": "Missing 'item' in request body"}, 400
+    return toggle_completion_item(auth_user.user_id, teamid, item_slug)
+
+
+@bp.route("/<teamid>/completion/complete", methods=["POST"])
+@auth.require_user
+def mark_team_complete_api(teamid):
+    """
+    Mark a team's project COMPLETE. Self-serve for team members. Requires all
+    8 checklist items to be done first. Posts a celebration message to the
+    team's Slack channel CCing the OHack admins.
+    """
+    logger.info(f"POST /team/{teamid}/completion/complete called")
+    if not (auth_user and auth_user.user_id):
+        return {"error": "Unauthorized"}, 401
+    return mark_team_complete(auth_user.user_id, teamid)
+
 
 @bp.route("/<teamid>/member", methods=["POST"])
 @auth.require_user

--- a/services/teams_service.py
+++ b/services/teams_service.py
@@ -6,7 +6,7 @@ from ratelimit import limits
 from firebase_admin import firestore
 
 from common.log import get_logger
-from common.utils.firestore_helpers import doc_to_json, log_execution_time
+from common.utils.firestore_helpers import doc_to_json, log_execution_time, register_cache
 from common.utils.slack import send_slack_audit, send_slack, create_slack_channel, invite_user_to_channel
 from common.utils.github import create_github_repo, validate_github_username, get_all_repos
 from common.utils.firebase import get_hackathon_by_event_id
@@ -59,8 +59,57 @@ def get_teams_list(id=None):
             return { "teams": results }
 
 
+def _enrich_team_users(team_data, db):
+    """
+    Replace team_data["users"] (list of user doc-id strings, as flattened by
+    doc_to_json) with a list of slim profile dicts so the public team page can
+    render real names + avatars without N round-trips from the frontend.
+
+    Safe to call repeatedly; a missing user doc becomes a stub instead of 500ing
+    the whole team request.
+    """
+    user_ids = team_data.get("users")
+    if not user_ids or not isinstance(user_ids, list):
+        return team_data
+
+    user_refs = [db.collection("users").document(uid) for uid in user_ids if isinstance(uid, str)]
+    if not user_refs:
+        return team_data
+
+    try:
+        snapshots = db.get_all(user_refs)
+    except Exception as e:
+        logger.warning(f"_enrich_team_users get_all failed, leaving ids in place: {e}")
+        return team_data
+
+    enriched = []
+    for snap in snapshots:
+        try:
+            if not snap.exists:
+                enriched.append({"id": snap.id, "name": None, "nickname": None, "profile_image": None, "user_id": None})
+                continue
+            d = snap.to_dict() or {}
+            enriched.append({
+                "id": snap.id,
+                "user_id": d.get("user_id"),
+                "name": d.get("name"),
+                "nickname": d.get("nickname"),
+                "profile_image": d.get("profile_image"),
+            })
+        except Exception as e:
+            logger.warning(f"_enrich_team_users per-user failure ({snap.id}): {e}")
+            enriched.append({"id": snap.id, "name": None, "nickname": None, "profile_image": None, "user_id": None})
+
+    team_data["users"] = enriched
+    return team_data
+
+
+_GET_TEAM_CACHE = TTLCache(maxsize=100, ttl=600)
+register_cache(_GET_TEAM_CACHE)
+
+
 @limits(calls=2000, period=THIRTY_SECONDS)
-@cached(cache=TTLCache(maxsize=100, ttl=600), key=lambda id: id)
+@cached(cache=_GET_TEAM_CACHE, key=lambda id: id)
 @log_execution_time
 def get_team(id):
     if id is None:
@@ -79,6 +128,7 @@ def get_team(id):
             return {}
 
         team_data = doc_to_json(docid=doc.id, doc=doc)
+        team_data = _enrich_team_users(team_data, db)
         logger.info(f"Successfully retrieved team with id={id}")
         return {
             "team" : team_data


### PR DESCRIPTION
## What does the PR do?

Backend half of the new interactive **project-completion checklist** on `/hack/<event_id>/team/<team_id>`. Winning teams take ~3 months post-hackathon to satisfy the 8-item [Definition of Done](https://ohack.dev/about/completion); today, that stretch is silent. With this change, each item a team member checks off broadcasts a celebration into the team's Slack channel, and the final "mark complete" broadcast CCs all OHack Slack admins.

Also fixes the bug where `/hack/.../team/<id>` rendered the literal string **"Team Member"** for every person, because `team.users[]` was being returned as a flat list of doc-id strings.

### Type of change
- [x] Bug Fix
- [x] New Feature
- [ ] Breaking Change

## Changes

### `services/teams_service.py` — enrich `get_team`
- New `_enrich_team_users(team_data, db)` helper: replaces `team.users[]` (doc-id strings) with `{id, user_id, name, nickname, profile_image}` dicts via a **single batched `db.get_all(...)`** (N+1-safe).
- Per-user `try/except` so a missing user doc doesn't 500 the whole team.
- Backwards-compatible — `HackathonResults.js`, `TeamList.js` etc. already handle both shapes (`typeof u === 'string' ? u : u?.user_id || u?.id`).
- The `get_team` `TTLCache` is now `register_cache()`-tracked, so `add_team_member`/`edit_team`/etc. correctly invalidate it (they were silently leaving it stale for up to 10 min).
- Scope: only the single-team getter is enriched. `get_teams_list()` and `get_teams_batch()` are untouched.

### `api/teams/teams_service.py` — completion service
- Promoted the inline `slack_admins` list to a module-level `TEAM_COMPLETION_SLACK_ADMINS` constant (single source of truth for both `queue_team()` admin invites and completion broadcasts).
- New canonical `COMPLETION_ITEMS` list — slugs MUST stay in lockstep with the frontend `COMPLETION_ITEMS` array. Item slugs: `deployed`, `nonprofit_signoff`, `login_details`, `code_updated`, `tasks_closed`, `sensitive_info_security`, `documentation`, `open_source`.
- `user_is_on_team(propel_user_id, team_id)` — translates the PropelAuth UUID → OAuth `user_id` via `get_propel_user_details_by_id` (same pattern as `get_my_teams_by_event_id`), with a `propel_id` direct-match fallback. (Identity matching here is non-obvious; PropelAuth's `auth_user.user_id` is the PropelAuth UUID, while user docs store the OAuth identity under `user_id` and the PropelAuth UUID under `propel_id`.)
- `toggle_completion_item(propel_user_id, team_id, item_slug)`:
  - 403 if caller is not on the team.
  - 409 if item is already `done=True` (no unchecking, no double-Slack).
  - Persists `completion_checklist[slug] = {done, completed_at, completed_by_*}`.
  - Recomputes `completion_status` (`in_progress` → `complete` when the 8th lands).
  - Sends `:white_check_mark: *{name}* checked off *{label}* (n/8 complete!)` into the team's `slack_channel`.
  - Audits via `send_slack_audit("completion_toggle", ...)` and clears caches.
- `mark_team_complete(propel_user_id, team_id)`:
  - 403 if caller is not on the team.
  - 409 if any item is missing or if already complete (idempotent — no double broadcast).
  - Posts a celebration message into the team's Slack channel with `<@admin>` mentions for all 6 admins.
  - Persists `completion_status="complete"` + `completion_completed_*` fields.

### `api/teams/teams_views.py` — two new self-serve routes
- `POST /api/team/<teamid>/completion/toggle` — body `{ "item": "<slug>" }`
- `POST /api/team/<teamid>/completion/complete` — body `{}`
- Both `@auth.require_user` + a `user_is_on_team()` check.

### New optional Firestore fields on a team doc (no migration; legacy docs stay valid)
- `completion_checklist: { [slug]: { done, completed_at, completed_by_propel_id, completed_by_name } }`
- `completion_status: "not_started" | "in_progress" | "complete"`
- `completion_completed_at`, `completion_completed_by_propel_id`, `completion_completed_by_name`

## Linked Issue
N/A — addresses a request from the OHack core team to make the post-hackathon completion stretch interactive and visible. The frontend half ships separately in `frontend-ohack.dev`.

## Reviewer notes

- **Identity-field gotcha** (load-bearing): user docs have TWO identity fields — `user_id` (OAuth handle, e.g. `oauth2|slack|...`, often empty) and `propel_id` (PropelAuth UUID, marked PII). Don't naïvely compare `auth_user.user_id` against `team.users[].user_id` — see `user_is_on_team()` for the right approach.
- The `_enrich_team_users` enrichment runs **inside** the `get_team` TTL cache, so the cost is amortized across requests within a 10-min window.
- `propel_id` is intentionally **not** included in the enriched user payload — the team API is public and `propel_id` is PII. Frontend membership checks use the already-authenticated `GET /api/team/<event_id>/me` endpoint instead.

## Make sure you have

- [x] Pulled from the default branch
- [x] Documented your changes
- [x] Linked the Issue (N/A)
- [ ] Appointed a reviewer (if any)

🤖 Generated with [Claude Code](https://claude.com/claude-code)