### PR TITLE
[Teams] Hotfix: completion toggle TTLCache + DocumentReference JSON errors

### DIFF
--- a/api/teams/teams_service.py
+++ b/api/teams/teams_service.py
@@ -3,7 +3,7 @@ import logging
 from datetime import datetime
 from db.db import get_db, get_user_doc_reference
 from api.messages.messages_service import get_problem_statement_from_id_old
-from services.teams_service import get_teams_list
+from services.teams_service import get_teams_list, get_team
 from services.nonprofits_service import get_single_npo
 from common.utils.firestore_helpers import clear_all_caches as clear_cache
 from services.users_service import (
@@ -1138,8 +1138,10 @@ def toggle_completion_item(propel_user_id, team_id, item_slug):
     )
     clear_cache()
 
-    fresh = team_doc.get().to_dict() or {}
-    fresh["id"] = team_id
+    # Route through get_team so DocumentReferences on users[] are flattened
+    # via doc_to_json + enriched into profile dicts (Flask can't JSON-serialize
+    # raw DocumentReference objects).
+    fresh = (get_team(team_id) or {}).get("team") or {}
     return {"success": True, "team": fresh, "done": done_n, "total": total_n}, 200
 
 
@@ -1200,6 +1202,5 @@ def mark_team_complete(propel_user_id, team_id):
     )
     clear_cache()
 
-    fresh = team_doc.get().to_dict() or {}
-    fresh["id"] = team_id
+    fresh = (get_team(team_id) or {}).get("team") or {}
     return {"success": True, "team": fresh}, 200

--- a/common/utils/firestore_helpers.py
+++ b/common/utils/firestore_helpers.py
@@ -20,11 +20,23 @@ def register_cache(cache_obj):
 
 
 def clear_all_caches():
-    """Clear all registered caches and the doc_to_json cache."""
+    """Clear all registered caches and the doc_to_json cache.
+
+    A registered entry may be either an @cached-decorated function (which
+    cachetools gives a `cache_clear()` method) or a raw cache object such
+    as a TTLCache (which uses `.clear()`). Try both.
+    """
     doc_to_json.cache_clear()
     for cache_obj in _cache_registry:
         try:
-            cache_obj.cache_clear()
+            if hasattr(cache_obj, "cache_clear"):
+                cache_obj.cache_clear()
+            elif hasattr(cache_obj, "clear"):
+                cache_obj.clear()
+            else:
+                logger.warning(
+                    f"Registered cache has neither cache_clear nor clear: {type(cache_obj).__name__}"
+                )
         except Exception as e:
             logger.warning(f"Failed to clear a registered cache: {e}")
 


### PR DESCRIPTION
## What does the PR do?

Hotfix for two production errors in `POST /api/team/<teamid>/completion/toggle` (introduced by #226). Symptoms in the deployed logs:

\`\`\`
WARNING - Failed to clear a registered cache: 'TTLCache' object has no attribute 'cache_clear'
ERROR - Exception on /api/team/<id>/completion/toggle [POST]
TypeError: Object of type DocumentReference is not JSON serializable
\`\`\`

### Type of change
- [x] Bug Fix

### Bug 1 — \`'TTLCache' object has no attribute 'cache_clear'\`
\`services/teams_service.py\` registered the raw \`TTLCache\` instance via \`register_cache(_GET_TEAM_CACHE)\`, but \`clear_all_caches()\` calls \`.cache_clear()\` on every registered entry. \`cache_clear()\` is the method that cachetools' \`@cached\` decorator adds to the *wrapped function*; bare cache objects expose \`.clear()\` instead. Result: every cache-invalidation attempt logged a warning and **silently left the get_team cache stale** for 10 minutes.

Fixed by making \`clear_all_caches()\` accept either method — \`cache_clear()\` first (covers \`@cached\`-decorated functions, the existing pattern), falling back to \`.clear()\` (covers bare cache objects). Forward-compatible with both registration styles.

### Bug 2 — \`TypeError: Object of type DocumentReference is not JSON serializable\`
\`toggle_completion_item\` and \`mark_team_complete\` were returning \`team_doc.get().to_dict()\` directly. That dict contains \`users[]\` as raw Firestore \`DocumentReference\` objects, which Flask's JSON encoder can't serialize. The toggle would persist the state change to Firestore AND post the celebration Slack message, then 500 when serializing the response — so the frontend never received the updated team and the optimistic UI rolled back, looking to the user like the toggle had failed.

Fixed by routing both return paths through \`get_team(team_id)\`, which already passes through \`doc_to_json\` (flattens DocumentReferences) and \`_enrich_team_users\` (replaces user IDs with profile dicts). The cache is cleared right before this call, so the fresh post-write state is fetched. Bonus: the frontend now gets the same enriched payload it consumes from \`GET /api/messages/team/<id>\`, so \`onTeamUpdate(updated)\` doesn't drop user names.

## Linked Issue
Hotfix for [#226](https://github.com/opportunity-hack/backend-ohack.dev/pull/226).

## Make sure you have
- [x] Pulled from the default branch
- [x] Documented your changes
- [x] Linked the Issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)