### PR TITLE
[Mentors] Per-team mentor support panel + leaderboard boost signals

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -185,6 +185,7 @@ def create_app():
     from api.llm import llm_views
     from api.store import store_views
     from api.planning import planning_views
+    from api.mentors import mentors_views
 
     app.register_blueprint(messages_views.bp)
     app.register_blueprint(exception_views.bp)
@@ -205,5 +206,6 @@ def create_app():
     app.register_blueprint(judging_views.bp)
     app.register_blueprint(store_views.bp)
     app.register_blueprint(planning_views.bp)
+    app.register_blueprint(mentors_views.bp)
 
     return app

--- a/api/leaderboard/leaderboard_service.py
+++ b/api/leaderboard/leaderboard_service.py
@@ -504,6 +504,105 @@ def categorize_mentor_opportunities(achievements: List[Dict]) -> List[Dict]:
 
     return opportunities
 
+
+def collect_mentor_panel_opportunities(event_id: str) -> List[Dict]:
+    """
+    Derive mentor-boost opportunities from the per-team mentor panel state:
+      - Any team with an open mentor flag (raised by a mentor)
+      - Any team that has had NO mentor touch in the last 4 hours during a
+        live event window (start_date <= now <= end_date + 1 day)
+
+    These are appended to the existing GitHub-derived opportunities so the
+    "Teams Ready for a Boost" widget on /hack/<event_id>#stats covers both
+    coding-activity AND mentor-coverage gaps.
+    """
+    from datetime import datetime, timedelta
+    from common.utils.firebase import get_hackathon_by_event_id
+    from db.db import get_db
+
+    opportunities: List[Dict] = []
+
+    try:
+        hackathon = get_hackathon_by_event_id(event_id) or {}
+    except Exception as e:
+        logger.warning("collect_mentor_panel_opportunities: hackathon lookup failed: %s", e)
+        hackathon = {}
+
+    now = datetime.now()
+    start_date = None
+    end_date = None
+    try:
+        if hackathon.get("start_date"):
+            start_date = datetime.fromisoformat(hackathon["start_date"].replace("Z", ""))
+        if hackathon.get("end_date"):
+            end_date = datetime.fromisoformat(hackathon["end_date"].replace("Z", ""))
+    except Exception:
+        pass
+    is_live = bool(
+        start_date and end_date and start_date <= now <= (end_date + timedelta(days=1))
+    )
+
+    try:
+        db = get_db()
+        team_docs = db.collection("teams").where("hackathon_event_id", "==", event_id).stream()
+    except Exception as e:
+        logger.warning("collect_mentor_panel_opportunities: team query failed: %s", e)
+        return opportunities
+
+    stale_threshold = now - timedelta(hours=4)
+
+    for snap in team_docs:
+        try:
+            t = snap.to_dict() or {}
+            team_name = t.get("name") or "Unnamed team"
+            team_id = snap.id
+
+            # Open flag → one opportunity per flag (cap at 2 per team to limit noise)
+            flags = t.get("mentor_flags") or []
+            open_flags = [f for f in flags if not f.get("resolved_at")][:2]
+            for f in open_flags:
+                severity = f.get("severity", "needs_attention")
+                body = (f.get("body") or "").strip()
+                preview = (body[:80] + "...") if len(body) > 80 else body
+                opportunities.append({
+                    "type": "mentor_opportunity",
+                    "team": team_name,
+                    "teamPage": f"https://www.ohack.dev/hack/{event_id}/team/{team_id}",
+                    "icon": "flag",
+                    "value": "Open flag" if severity == "needs_attention" else "Blocked",
+                    "description": f"{f.get('raised_by_name', 'Mentor')}: {preview}",
+                    "members": len(t.get("users") or []),
+                })
+
+            # No mentor touch in 4h during a live event
+            if is_live:
+                last_touched_iso = t.get("mentor_last_touched_at")
+                touched_recently = False
+                if last_touched_iso:
+                    try:
+                        last_touched = datetime.fromisoformat(last_touched_iso.replace("Z", ""))
+                        if last_touched >= stale_threshold:
+                            touched_recently = True
+                    except Exception:
+                        pass
+                if not touched_recently:
+                    opportunities.append({
+                        "type": "mentor_opportunity",
+                        "team": team_name,
+                        "teamPage": f"https://www.ohack.dev/hack/{event_id}/team/{team_id}",
+                        "icon": "schedule",
+                        "value": "No mentor touch in 4h",
+                        "description": (
+                            "No mentor has checked on this team in the last 4 hours — drop by!"
+                        ),
+                        "members": len(t.get("users") or []),
+                    })
+        except Exception as e:
+            logger.warning("collect_mentor_panel_opportunities: skipped a team: %s", e)
+            continue
+
+    return opportunities
+
 def get_leaderboard_analytics(event_id: str, contributors: List[Dict], achievements: List[Dict]) -> Dict[str, Any]:
     """
     Generate leaderboard analytics including statistics and achievements.
@@ -541,6 +640,13 @@ def get_leaderboard_analytics(event_id: str, contributors: List[Dict], achieveme
     individual_achievements = categorize_individual_achievements(achievements)
     team_achievements = categorize_team_achievements(achievements, contributors)
     mentor_opportunities = categorize_mentor_opportunities(achievements)
+
+    # Append mentor-panel-derived opportunities (open flags + stale touch).
+    # Best-effort: any failure here must not break the broader leaderboard.
+    try:
+        mentor_opportunities = mentor_opportunities + collect_mentor_panel_opportunities(event_id)
+    except Exception as e:
+        logger.warning("Failed to collect mentor panel opportunities for %s: %s", event_id, e)
 
     return {
         "eventName": event_name,

--- a/api/mentors/mentors_service.py
+++ b/api/mentors/mentors_service.py
@@ -39,14 +39,17 @@ MENTOR_COVERAGE_ITEMS = [
     {"slug": "repo_health_checked", "label": "GitHub repo reviewed",
      "blurb": "Commits flowing, structure sensible, README starting to take shape."},
     {"slug": "criteria_walkthrough", "label": "Judging criteria walkthrough",
-     "blurb": "Team has been shown the 4-criterion rubric and knows what judges look for."},
+     "blurb": "Team has been shown the judging rubric (Scope, Documentation, Polish, Security, plus Accessibility) and knows what judges look for."},
     {"slug": "demo_devpost_reviewed", "label": "Demo video + DevPost reviewed",
      "blurb": "A mentor has reviewed at least a draft of the demo video and DevPost submission."},
 ]
 MENTOR_COVERAGE_SLUGS = {item["slug"]: item for item in MENTOR_COVERAGE_ITEMS}
 
 ALLOWED_FLAG_SEVERITIES = {"needs_attention", "blocked"}
-ALLOWED_CRITERIA = {"scope", "documentation", "polish", "security"}
+# Five judging criteria. The first four are the main 10-pt rubric on
+# /about/judges; "accessibility" is the special-category prize on the same
+# page but mentors still coach for it, so it lives in the same set.
+ALLOWED_CRITERIA = {"scope", "documentation", "polish", "security", "accessibility"}
 ALLOWED_SCORES = {"green", "yellow", "red"}
 
 MAX_NOTE_LEN = 1000

--- a/api/mentors/mentors_service.py
+++ b/api/mentors/mentors_service.py
@@ -1,0 +1,572 @@
+"""
+Per-team mentor support panel — backend service.
+
+Lets multiple approved mentors collaborate on a team during a hackathon:
+mark coverage items done, leave public notes, raise/own/resolve flags,
+rate judging-readiness on a 4-criterion rubric. All data is public-read
+(reads come through the existing get_team / mentor-feed endpoint); writes
+require a volunteer doc with volunteer_type='mentor', isSelected=True,
+matched to the caller's PropelAuth identity for this event.
+
+Slack notifications are deliberately quiet: only flag-raises, flag-resolutions,
+and the team's first "all coverage covered" milestone broadcast to the team
+channel; flag-raises also heartbeat the per-event mentor channel.
+"""
+import uuid
+import logging
+from datetime import datetime
+from typing import Optional, Tuple
+
+from db.db import get_db
+from common.utils.firestore_helpers import clear_all_caches as clear_cache
+from common.utils.slack import send_slack, send_slack_audit
+from common.utils.firebase import get_hackathon_by_event_id
+from services.users_service import get_propel_user_details_by_id
+from services.volunteers_service import get_volunteer_by_email, get_volunteer_by_user_id
+from services.teams_service import get_team
+
+logger = logging.getLogger("myapp")
+
+# Canonical 6-item team-coverage list. Slugs MUST stay in lockstep with the
+# frontend MENTOR_COVERAGE_ITEMS in src/components/Teams/mentorCoverage.js.
+MENTOR_COVERAGE_ITEMS = [
+    {"slug": "intro_made", "label": "Mentor introductions made",
+     "blurb": "A mentor has connected with the team in their Slack channel."},
+    {"slug": "scope_reviewed", "label": "Project scope reviewed",
+     "blurb": "Scope is realistic for the hackathon window and ties to a real nonprofit need."},
+    {"slug": "architecture_discussed", "label": "Architecture & tech stack discussed",
+     "blurb": "Stack is sensible; nothing single-file or trivially shallow."},
+    {"slug": "repo_health_checked", "label": "GitHub repo reviewed",
+     "blurb": "Commits flowing, structure sensible, README starting to take shape."},
+    {"slug": "criteria_walkthrough", "label": "Judging criteria walkthrough",
+     "blurb": "Team has been shown the 4-criterion rubric and knows what judges look for."},
+    {"slug": "demo_devpost_reviewed", "label": "Demo video + DevPost reviewed",
+     "blurb": "A mentor has reviewed at least a draft of the demo video and DevPost submission."},
+]
+MENTOR_COVERAGE_SLUGS = {item["slug"]: item for item in MENTOR_COVERAGE_ITEMS}
+
+ALLOWED_FLAG_SEVERITIES = {"needs_attention", "blocked"}
+ALLOWED_CRITERIA = {"scope", "documentation", "polish", "security"}
+ALLOWED_SCORES = {"green", "yellow", "red"}
+
+MAX_NOTE_LEN = 1000
+MAX_FLAG_BODY_LEN = 500
+MAX_RATING_NOTE_LEN = 300
+
+
+# -------- identity / auth --------------------------------------------------
+
+def _resolve_caller(propel_user_id):
+    """
+    Return (email, oauth_user_id, name) for the calling PropelAuth user.
+    Any of those three can be used to match against a volunteer doc.
+    """
+    try:
+        details = get_propel_user_details_by_id(propel_user_id) or ()
+        email = details[0] if len(details) > 0 else None
+        oauth_user_id = details[1] if len(details) > 1 else None
+        name = details[4] if len(details) > 4 else None
+        return email, oauth_user_id, name
+    except Exception as e:
+        logger.warning("mentors._resolve_caller failed: %s", e)
+        return None, None, None
+
+
+def user_is_mentor_for_event(propel_user_id, event_id) -> bool:
+    """
+    True iff the caller has an approved (isSelected=True) mentor volunteer
+    record for THIS event. Matches by email first, then by OAuth user_id —
+    either is enough.
+    """
+    if not propel_user_id or not event_id:
+        return False
+    email, oauth_user_id, _ = _resolve_caller(propel_user_id)
+
+    candidates = []
+    if email:
+        try:
+            v = get_volunteer_by_email(email, event_id, "mentor")
+            if v:
+                candidates.append(v)
+        except Exception as e:
+            logger.warning("user_is_mentor_for_event: email lookup failed: %s", e)
+    if oauth_user_id:
+        try:
+            v = get_volunteer_by_user_id(oauth_user_id, event_id, "mentor")
+            if v:
+                candidates.append(v)
+        except Exception as e:
+            logger.warning("user_is_mentor_for_event: user_id lookup failed: %s", e)
+
+    for v in candidates:
+        if v.get("isSelected"):
+            return True
+    return False
+
+
+def get_mentor_self_status(propel_user_id, event_id):
+    """
+    Returns { is_mentor, volunteer } for the GET /api/volunteer/<event_id>/me
+    endpoint. The volunteer subset is intentionally lean (no PII beyond what
+    the caller already knows about themselves).
+    """
+    if not propel_user_id or not event_id:
+        return {"is_mentor": False, "volunteer": None}
+    email, oauth_user_id, _ = _resolve_caller(propel_user_id)
+    chosen = None
+    if email:
+        try:
+            v = get_volunteer_by_email(email, event_id, "mentor")
+            if v and v.get("isSelected"):
+                chosen = v
+        except Exception:
+            pass
+    if chosen is None and oauth_user_id:
+        try:
+            v = get_volunteer_by_user_id(oauth_user_id, event_id, "mentor")
+            if v and v.get("isSelected"):
+                chosen = v
+        except Exception:
+            pass
+    if chosen is None:
+        return {"is_mentor": False, "volunteer": None}
+    return {
+        "is_mentor": True,
+        "volunteer": {
+            "name": chosen.get("name"),
+            "email": chosen.get("email"),
+            "isSelected": True,
+            "checkInTime": chosen.get("checkInTime"),
+        },
+    }
+
+
+# -------- shared helpers ---------------------------------------------------
+
+def _team_doc_or_404(team_id):
+    db = get_db()
+    ref = db.collection("teams").document(team_id)
+    snap = ref.get()
+    if not snap.exists:
+        return None, None, None
+    return ref, snap.to_dict() or {}, db
+
+
+def _caller_attribution(propel_user_id):
+    _, _, name = _resolve_caller(propel_user_id)
+    return name or "A mentor"
+
+
+def _touch(team_data, name, now_iso):
+    """Mutate team_data in-place with denormalized last-touch info."""
+    team_data["mentor_last_touched_at"] = now_iso
+    team_data["mentor_last_touched_by_name"] = name
+
+
+def _open_flag_count(flags):
+    if not isinstance(flags, list):
+        return 0
+    return sum(1 for f in flags if not f.get("resolved_at"))
+
+
+def _coverage_done_count(checklist):
+    if not isinstance(checklist, dict):
+        return 0
+    return sum(1 for slug in MENTOR_COVERAGE_SLUGS if checklist.get(slug, {}).get("done"))
+
+
+def _mentor_channel_for_event(event_id):
+    """Resolve the per-event mentor Slack channel — explicit field, then
+    fallback to a name-derived guess. Returns None if neither is available."""
+    if not event_id:
+        return None
+    try:
+        h = get_hackathon_by_event_id(event_id) or {}
+        explicit = h.get("mentor_slack_channel")
+        if explicit:
+            return explicit
+    except Exception as e:
+        logger.warning("_mentor_channel_for_event: hackathon lookup failed: %s", e)
+    # Fallback: <event_id>-mentors (deliberate convention; harmless if the
+    # channel doesn't exist — send_slack will just log and move on).
+    return f"{event_id}-mentors".replace("_", "-").lower()
+
+
+def _project_link(team_data, team_id):
+    event_id = team_data.get("hackathon_event_id") or ""
+    if event_id:
+        return f"https://ohack.dev/hack/{event_id}/team/{team_id}"
+    return f"https://ohack.dev/hack/team/{team_id}"
+
+
+def _build_response(team_id, **extra):
+    """Round-trip the team through get_team so users[] DocumentReferences are
+    flattened + enriched (Flask can't JSON-serialize raw refs)."""
+    fresh = (get_team(team_id) or {}).get("team") or {}
+    return {"success": True, "team": fresh, **extra}, 200
+
+
+# -------- coverage checklist ----------------------------------------------
+
+def toggle_mentor_coverage(propel_user_id, team_id, item_slug, done, note=None):
+    """
+    Mark/unmark a coverage item. Mentor coverage is reversible (situations
+    evolve mid-event), unlike the team-completion checklist. Quiet by
+    default — only the first time a team hits 6/6 does a Slack message fire.
+    """
+    if item_slug not in MENTOR_COVERAGE_SLUGS:
+        return {"error": f"Unknown coverage item: {item_slug}"}, 400
+    if not isinstance(done, bool):
+        return {"error": "Field 'done' must be a boolean"}, 400
+
+    event_id_guess = None
+    ref, team_data, _ = _team_doc_or_404(team_id)
+    if ref is None:
+        return {"error": "Team not found"}, 404
+    event_id_guess = team_data.get("hackathon_event_id")
+    if not user_is_mentor_for_event(propel_user_id, event_id_guess):
+        return {"error": "You must be an approved mentor for this event."}, 403
+
+    name = _caller_attribution(propel_user_id)
+    now_iso = datetime.now().isoformat()
+    checklist = dict(team_data.get("mentor_checklist") or {})
+    if done:
+        new_entry = {
+            "done": True,
+            "checked_at": now_iso,
+            "checked_by_propel_id": propel_user_id,
+            "checked_by_name": name,
+        }
+        if note:
+            new_entry["note"] = str(note)[:MAX_RATING_NOTE_LEN]
+        checklist[item_slug] = new_entry
+    else:
+        # Unchecking: drop the entry entirely (the absence is the "not done" state).
+        checklist.pop(item_slug, None)
+
+    new_count = sum(1 for s in MENTOR_COVERAGE_SLUGS if checklist.get(s, {}).get("done"))
+    total = len(MENTOR_COVERAGE_ITEMS)
+
+    update = {"mentor_checklist": checklist}
+    _touch(update, name, now_iso)
+
+    # First-time-complete milestone: stamp it once so we never re-broadcast.
+    fire_milestone = False
+    if done and new_count == total and not team_data.get("mentor_coverage_completed_at"):
+        update["mentor_coverage_completed_at"] = now_iso
+        update["mentor_coverage_completed_by_name"] = name
+        fire_milestone = True
+
+    ref.set(update, merge=True)
+
+    if fire_milestone:
+        slack_channel = team_data.get("slack_channel")
+        if slack_channel:
+            try:
+                send_slack(
+                    message=(
+                        f":sparkles: *{team_data.get('name', 'This team')}* has full mentor coverage "
+                        f"({total}/{total} items)! Nice work team & mentors. "
+                        f"Final coverage marker: *{name}*."
+                    ),
+                    channel=slack_channel,
+                )
+            except Exception as e:
+                logger.error("toggle_mentor_coverage: milestone slack failed: %s", e)
+
+    send_slack_audit(
+        action="mentor_coverage_toggle",
+        message=f"Team {team_id} coverage {item_slug}={done} by {name} ({new_count}/{total})",
+        payload={"team_id": team_id, "item": item_slug, "done": done, "by": propel_user_id},
+    )
+    clear_cache()
+    return _build_response(team_id, done=new_count, total=total)
+
+
+# -------- notes feed ------------------------------------------------------
+
+def add_mentor_note(propel_user_id, team_id, body):
+    if not body or not isinstance(body, str):
+        return {"error": "Note body is required"}, 400
+    body = body.strip()
+    if not body:
+        return {"error": "Note body is required"}, 400
+    if len(body) > MAX_NOTE_LEN:
+        return {"error": f"Note body must be at most {MAX_NOTE_LEN} characters"}, 400
+
+    ref, team_data, _ = _team_doc_or_404(team_id)
+    if ref is None:
+        return {"error": "Team not found"}, 404
+    event_id = team_data.get("hackathon_event_id")
+    if not user_is_mentor_for_event(propel_user_id, event_id):
+        return {"error": "You must be an approved mentor for this event."}, 403
+
+    name = _caller_attribution(propel_user_id)
+    now_iso = datetime.now().isoformat()
+    notes = list(team_data.get("mentor_notes") or [])
+    notes.append({
+        "id": uuid.uuid4().hex,
+        "created_at": now_iso,
+        "author_propel_id": propel_user_id,
+        "author_name": name,
+        "body": body,
+    })
+
+    update = {"mentor_notes": notes}
+    _touch(update, name, now_iso)
+    ref.set(update, merge=True)
+
+    send_slack_audit(
+        action="mentor_note_add",
+        message=f"Mentor note added on team {team_id} by {name}",
+        payload={"team_id": team_id, "by": propel_user_id, "len": len(body)},
+    )
+    clear_cache()
+    return _build_response(team_id)
+
+
+def delete_mentor_note(propel_user_id, team_id, note_id):
+    ref, team_data, _ = _team_doc_or_404(team_id)
+    if ref is None:
+        return {"error": "Team not found"}, 404
+    event_id = team_data.get("hackathon_event_id")
+    if not user_is_mentor_for_event(propel_user_id, event_id):
+        return {"error": "You must be an approved mentor for this event."}, 403
+
+    notes = list(team_data.get("mentor_notes") or [])
+    target = next((n for n in notes if n.get("id") == note_id), None)
+    if target is None:
+        return {"error": "Note not found"}, 404
+    if target.get("deleted_at"):
+        return {"error": "Note already deleted"}, 409
+    if target.get("author_propel_id") != propel_user_id:
+        return {"error": "You can only delete your own notes."}, 403
+
+    name = _caller_attribution(propel_user_id)
+    now_iso = datetime.now().isoformat()
+    target["deleted_at"] = now_iso
+    target["deleted_by_propel_id"] = propel_user_id
+
+    update = {"mentor_notes": notes}
+    _touch(update, name, now_iso)
+    ref.set(update, merge=True)
+
+    send_slack_audit(
+        action="mentor_note_delete",
+        message=f"Mentor note {note_id} soft-deleted on team {team_id} by {name}",
+        payload={"team_id": team_id, "note_id": note_id, "by": propel_user_id},
+    )
+    clear_cache()
+    return _build_response(team_id)
+
+
+# -------- flags -----------------------------------------------------------
+
+def raise_mentor_flag(propel_user_id, team_id, severity, body):
+    if severity not in ALLOWED_FLAG_SEVERITIES:
+        return {"error": f"Severity must be one of: {sorted(ALLOWED_FLAG_SEVERITIES)}"}, 400
+    if not body or not isinstance(body, str):
+        return {"error": "Flag body is required"}, 400
+    body = body.strip()
+    if not body:
+        return {"error": "Flag body is required"}, 400
+    if len(body) > MAX_FLAG_BODY_LEN:
+        return {"error": f"Flag body must be at most {MAX_FLAG_BODY_LEN} characters"}, 400
+
+    ref, team_data, _ = _team_doc_or_404(team_id)
+    if ref is None:
+        return {"error": "Team not found"}, 404
+    event_id = team_data.get("hackathon_event_id")
+    if not user_is_mentor_for_event(propel_user_id, event_id):
+        return {"error": "You must be an approved mentor for this event."}, 403
+
+    name = _caller_attribution(propel_user_id)
+    now_iso = datetime.now().isoformat()
+    flags = list(team_data.get("mentor_flags") or [])
+    new_flag = {
+        "id": uuid.uuid4().hex,
+        "created_at": now_iso,
+        "raised_by_propel_id": propel_user_id,
+        "raised_by_name": name,
+        "severity": severity,
+        "body": body,
+        "owner_propel_id": propel_user_id,
+        "owner_name": name,
+    }
+    flags.append(new_flag)
+
+    update = {
+        "mentor_flags": flags,
+        "mentor_open_flag_count": _open_flag_count(flags),
+    }
+    _touch(update, name, now_iso)
+    ref.set(update, merge=True)
+
+    # Loud: post into team channel + heartbeat the per-event mentor channel.
+    team_name = team_data.get("name", "this team")
+    project_link = _project_link(team_data, team_id)
+    severity_emoji = ":warning:" if severity == "needs_attention" else ":rotating_light:"
+    team_msg = (
+        f"{severity_emoji} *Mentor flag raised on {team_name}* by *{name}*\n"
+        f">{body}\n"
+        f"Owned by *{name}*. Other mentors can take over from the team page.\n"
+        f"{project_link}"
+    )
+    slack_channel = team_data.get("slack_channel")
+    if slack_channel:
+        try:
+            send_slack(message=team_msg, channel=slack_channel)
+        except Exception as e:
+            logger.error("raise_mentor_flag: team-channel slack failed: %s", e)
+
+    mentor_channel = _mentor_channel_for_event(event_id)
+    if mentor_channel:
+        try:
+            send_slack(
+                message=(
+                    f"{severity_emoji} *{team_name}*: {body[:120]}"
+                    f"{'...' if len(body) > 120 else ''}\n{project_link}"
+                ),
+                channel=mentor_channel,
+            )
+        except Exception as e:
+            logger.warning("raise_mentor_flag: mentor-channel slack failed: %s", e)
+
+    send_slack_audit(
+        action="mentor_flag_raise",
+        message=f"Flag raised on team {team_id} by {name} ({severity})",
+        payload={"team_id": team_id, "severity": severity, "by": propel_user_id},
+    )
+    clear_cache()
+    return _build_response(team_id, flag_id=new_flag["id"])
+
+
+def take_over_mentor_flag(propel_user_id, team_id, flag_id):
+    ref, team_data, _ = _team_doc_or_404(team_id)
+    if ref is None:
+        return {"error": "Team not found"}, 404
+    event_id = team_data.get("hackathon_event_id")
+    if not user_is_mentor_for_event(propel_user_id, event_id):
+        return {"error": "You must be an approved mentor for this event."}, 403
+
+    flags = list(team_data.get("mentor_flags") or [])
+    target = next((f for f in flags if f.get("id") == flag_id), None)
+    if target is None:
+        return {"error": "Flag not found"}, 404
+    if target.get("resolved_at"):
+        return {"error": "Flag is already resolved"}, 409
+
+    name = _caller_attribution(propel_user_id)
+    now_iso = datetime.now().isoformat()
+    target["owner_propel_id"] = propel_user_id
+    target["owner_name"] = name
+
+    update = {"mentor_flags": flags}
+    _touch(update, name, now_iso)
+    ref.set(update, merge=True)
+
+    send_slack_audit(
+        action="mentor_flag_takeover",
+        message=f"Flag {flag_id} on team {team_id} taken over by {name}",
+        payload={"team_id": team_id, "flag_id": flag_id, "by": propel_user_id},
+    )
+    clear_cache()
+    return _build_response(team_id)
+
+
+def resolve_mentor_flag(propel_user_id, team_id, flag_id, resolution_note):
+    if not resolution_note or not str(resolution_note).strip():
+        return {"error": "Resolution note is required"}, 400
+    resolution_note = str(resolution_note).strip()[:MAX_FLAG_BODY_LEN]
+
+    ref, team_data, _ = _team_doc_or_404(team_id)
+    if ref is None:
+        return {"error": "Team not found"}, 404
+    event_id = team_data.get("hackathon_event_id")
+    if not user_is_mentor_for_event(propel_user_id, event_id):
+        return {"error": "You must be an approved mentor for this event."}, 403
+
+    flags = list(team_data.get("mentor_flags") or [])
+    target = next((f for f in flags if f.get("id") == flag_id), None)
+    if target is None:
+        return {"error": "Flag not found"}, 404
+    if target.get("resolved_at"):
+        return {"error": "Flag is already resolved"}, 409
+
+    name = _caller_attribution(propel_user_id)
+    now_iso = datetime.now().isoformat()
+    target["resolved_at"] = now_iso
+    target["resolved_by_propel_id"] = propel_user_id
+    target["resolved_by_name"] = name
+    target["resolution_note"] = resolution_note
+
+    update = {
+        "mentor_flags": flags,
+        "mentor_open_flag_count": _open_flag_count(flags),
+    }
+    _touch(update, name, now_iso)
+    ref.set(update, merge=True)
+
+    team_name = team_data.get("name", "this team")
+    slack_channel = team_data.get("slack_channel")
+    if slack_channel:
+        try:
+            send_slack(
+                message=(
+                    f":white_check_mark: *Mentor flag resolved on {team_name}* by *{name}*\n"
+                    f">{resolution_note}"
+                ),
+                channel=slack_channel,
+            )
+        except Exception as e:
+            logger.error("resolve_mentor_flag: slack failed: %s", e)
+
+    send_slack_audit(
+        action="mentor_flag_resolve",
+        message=f"Flag {flag_id} on team {team_id} resolved by {name}",
+        payload={"team_id": team_id, "flag_id": flag_id, "by": propel_user_id},
+    )
+    clear_cache()
+    return _build_response(team_id)
+
+
+# -------- judging-readiness rating ----------------------------------------
+
+def set_mentor_rating(propel_user_id, team_id, criterion, score, note=None):
+    if criterion not in ALLOWED_CRITERIA:
+        return {"error": f"Criterion must be one of: {sorted(ALLOWED_CRITERIA)}"}, 400
+    if score not in ALLOWED_SCORES:
+        return {"error": f"Score must be one of: {sorted(ALLOWED_SCORES)}"}, 400
+
+    ref, team_data, _ = _team_doc_or_404(team_id)
+    if ref is None:
+        return {"error": "Team not found"}, 404
+    event_id = team_data.get("hackathon_event_id")
+    if not user_is_mentor_for_event(propel_user_id, event_id):
+        return {"error": "You must be an approved mentor for this event."}, 403
+
+    name = _caller_attribution(propel_user_id)
+    now_iso = datetime.now().isoformat()
+    ratings = list(team_data.get("mentor_ratings") or [])
+    entry = {
+        "rated_at": now_iso,
+        "rated_by_propel_id": propel_user_id,
+        "rated_by_name": name,
+        "criterion": criterion,
+        "score": score,
+    }
+    if note:
+        entry["note"] = str(note).strip()[:MAX_RATING_NOTE_LEN]
+    ratings.append(entry)
+
+    update = {"mentor_ratings": ratings}
+    _touch(update, name, now_iso)
+    ref.set(update, merge=True)
+
+    send_slack_audit(
+        action="mentor_rating_set",
+        message=f"Rating {criterion}={score} set on team {team_id} by {name}",
+        payload={"team_id": team_id, "criterion": criterion, "score": score, "by": propel_user_id},
+    )
+    clear_cache()
+    return _build_response(team_id)

--- a/api/mentors/mentors_views.py
+++ b/api/mentors/mentors_views.py
@@ -1,0 +1,116 @@
+"""
+Per-team mentor support panel — Flask routes.
+
+All mutating routes require an authenticated user; the underlying service
+functions also verify the caller has an approved (isSelected=True) mentor
+volunteer record for THIS event. The public read goes through the existing
+GET /api/messages/team/<id> path (no new GET needed — mentor_* fields are
+already part of the team doc).
+"""
+import logging
+from flask import Blueprint, request
+
+from common.auth import auth, auth_user
+from api.mentors.mentors_service import (
+    add_mentor_note,
+    delete_mentor_note,
+    raise_mentor_flag,
+    take_over_mentor_flag,
+    resolve_mentor_flag,
+    toggle_mentor_coverage,
+    set_mentor_rating,
+)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+bp_name = "api-mentors"
+bp_url_prefix = "/api/team"
+bp = Blueprint(bp_name, __name__, url_prefix=bp_url_prefix)
+
+
+def _unauthorized():
+    return {"error": "Unauthorized"}, 401
+
+
+@bp.route("/<teamid>/mentor/coverage", methods=["POST"])
+@auth.require_user
+def toggle_mentor_coverage_api(teamid):
+    """Body: { item: <slug>, done: bool, note?: str }"""
+    if not (auth_user and auth_user.user_id):
+        return _unauthorized()
+    body = request.get_json() or {}
+    item = body.get("item")
+    done = body.get("done")
+    note = body.get("note")
+    if item is None or done is None:
+        return {"error": "Both 'item' and 'done' are required"}, 400
+    return toggle_mentor_coverage(auth_user.user_id, teamid, item, bool(done), note=note)
+
+
+@bp.route("/<teamid>/mentor/notes", methods=["POST"])
+@auth.require_user
+def add_mentor_note_api(teamid):
+    """Body: { body: str }"""
+    if not (auth_user and auth_user.user_id):
+        return _unauthorized()
+    body = request.get_json() or {}
+    text = body.get("body")
+    return add_mentor_note(auth_user.user_id, teamid, text)
+
+
+@bp.route("/<teamid>/mentor/notes/<note_id>", methods=["DELETE"])
+@auth.require_user
+def delete_mentor_note_api(teamid, note_id):
+    if not (auth_user and auth_user.user_id):
+        return _unauthorized()
+    return delete_mentor_note(auth_user.user_id, teamid, note_id)
+
+
+@bp.route("/<teamid>/mentor/flags", methods=["POST"])
+@auth.require_user
+def raise_mentor_flag_api(teamid):
+    """Body: { severity: 'needs_attention'|'blocked', body: str }"""
+    if not (auth_user and auth_user.user_id):
+        return _unauthorized()
+    body = request.get_json() or {}
+    severity = body.get("severity")
+    text = body.get("body")
+    if not severity or not text:
+        return {"error": "Both 'severity' and 'body' are required"}, 400
+    return raise_mentor_flag(auth_user.user_id, teamid, severity, text)
+
+
+@bp.route("/<teamid>/mentor/flags/<flag_id>/take-over", methods=["POST"])
+@auth.require_user
+def take_over_mentor_flag_api(teamid, flag_id):
+    if not (auth_user and auth_user.user_id):
+        return _unauthorized()
+    return take_over_mentor_flag(auth_user.user_id, teamid, flag_id)
+
+
+@bp.route("/<teamid>/mentor/flags/<flag_id>/resolve", methods=["POST"])
+@auth.require_user
+def resolve_mentor_flag_api(teamid, flag_id):
+    """Body: { resolution_note: str }"""
+    if not (auth_user and auth_user.user_id):
+        return _unauthorized()
+    body = request.get_json() or {}
+    note = body.get("resolution_note")
+    return resolve_mentor_flag(auth_user.user_id, teamid, flag_id, note)
+
+
+@bp.route("/<teamid>/mentor/ratings", methods=["POST"])
+@auth.require_user
+def set_mentor_rating_api(teamid):
+    """Body: { criterion: 'scope'|'documentation'|'polish'|'security',
+              score: 'green'|'yellow'|'red', note?: str }"""
+    if not (auth_user and auth_user.user_id):
+        return _unauthorized()
+    body = request.get_json() or {}
+    criterion = body.get("criterion")
+    score = body.get("score")
+    note = body.get("note")
+    if not criterion or not score:
+        return {"error": "Both 'criterion' and 'score' are required"}, 400
+    return set_mentor_rating(auth_user.user_id, teamid, criterion, score, note=note)

--- a/api/volunteers/volunteers_views.py
+++ b/api/volunteers/volunteers_views.py
@@ -214,6 +214,26 @@ def admin_list_mentors(user, org, event_id):
     """Admin endpoint to list mentor applications."""
     return handle_admin_list(user, event_id, 'mentor')
 
+
+@bp.route('/volunteer/<event_id>/me', methods=['GET'])
+@auth.require_user
+def get_my_volunteer_status_for_event(event_id):
+    """
+    Lightweight self-check for the calling user against a single event.
+    Default type is 'mentor' (used by the per-team mentor panel to decide
+    interactive vs. read-only).
+    Returns { is_mentor: bool, volunteer: {name, email, isSelected, checkInTime?} | null }.
+    """
+    user = auth_user
+    if not user or not user.user_id:
+        return _error_response("Authentication required", 401)
+    vtype = request.args.get('type', 'mentor')
+    if vtype != 'mentor':
+        # Keep the surface narrow for now; extend later if needed.
+        return _error_response("Only type=mentor is supported", 400)
+    from api.mentors.mentors_service import get_mentor_self_status
+    return get_mentor_self_status(user.user_id, event_id)
+
 # Sponsor routes
 @bp.route('/sponsor/application/<event_id>/submit', methods=['POST'])
 @auth.optional_user

--- a/common/utils/validators.py
+++ b/common/utils/validators.py
@@ -297,6 +297,15 @@ def validate_hackathon_data_partial(data):
             _skip("planning", str(e))
             cleaned.pop("planning")
 
+    # mentor_slack_channel — optional channel-name string for the per-event
+    # mentor coordination channel. The per-team MentorTeamPanel falls back to
+    # a name-derived guess ("<event_id>-mentors") when this is unset.
+    if "mentor_slack_channel" in cleaned and cleaned["mentor_slack_channel"] is not None:
+        msc = cleaned["mentor_slack_channel"]
+        if not isinstance(msc, str) or len(msc) > 80:
+            _skip("mentor_slack_channel", "must be a string <= 80 chars (Slack channel name)")
+            cleaned.pop("mentor_slack_channel")
+
     return cleaned, skipped
 
 


### PR DESCRIPTION
## What does the PR do?

Backend half of a new per-team **mentor coordination panel** on `/hack/<event_id>/team/<team_id>`. Pairs with the matching frontend PR in [opportunity-hack/frontend-ohack.dev](https://github.com/opportunity-hack/frontend-ohack.dev) (link to be added once pushed).

Today the OHack mentor experience is documented (`/about/mentors`) but invisible to other mentors during an event — multiple mentors visit the same teams, work gets duplicated, off-shift mentors miss what others observed, and there's no durable record of which teams were under-supported. This change makes mentor work **visible, attributable, and coordinated**, so mentors don't trip over each other and non-technical mentors can read what a technical mentor saw earlier without bothering them on Slack.

### Type of change
- [x] New Feature

## What's in the change

### New module `api/mentors`
- **`mentors_service.py`**
  - `MENTOR_COVERAGE_ITEMS` — canonical 6-item team-observation checklist (intro_made, scope_reviewed, architecture_discussed, repo_health_checked, criteria_walkthrough, demo_devpost_reviewed). **Slugs MUST stay in lockstep** with the frontend `MENTOR_COVERAGE_ITEMS` array (same contract as `COMPLETION_ITEMS` from #226).
  - `user_is_mentor_for_event()` — auth gate. Translates the PropelAuth UUID to OAuth `user_id` + email via `get_propel_user_details_by_id`, then looks up a volunteers doc with `volunteer_type='mentor'`, `event_id=<this event>`, `isSelected=True`. Matches by email OR user_id for robustness (same identity gotcha pattern as `user_is_on_team`).
  - `get_mentor_self_status()` — backs the new `/api/volunteer/<event_id>/me` endpoint with a lean `{is_mentor, volunteer}` payload (no PII beyond what the caller already knows about themselves).
  - Full CRUD: `toggle_mentor_coverage`, `add_mentor_note`, `delete_mentor_note`, `raise_mentor_flag`, `take_over_mentor_flag`, `resolve_mentor_flag`, `set_mentor_rating`.
  - **Slack volume is intentionally QUIET** (UX decision confirmed with maintainer): only flag-raises, flag-resolutions, and the first-time *all 6 covered* milestone broadcast to the team's `slack_channel`. Flag-raises also heartbeat the per-event mentor channel. Coverage toggles, notes, take-overs, and ratings are silent — they still write to `send_slack_audit` for the audit trail.
  - All write paths route the response through `get_team()` so DocumentRefs on `users[]` are flattened + enriched (same fix as #227).
- **`mentors_views.py`** — 7 routes under `/api/team/<teamid>/mentor/...`: `coverage` (POST), `notes` (POST), `notes/<id>` (DELETE), `flags` (POST), `flags/<id>/take-over` (POST), `flags/<id>/resolve` (POST), `ratings` (POST). All `@auth.require_user`; service layer enforces the mentor gate.

### `api/__init__.py`
Registers the new mentors blueprint alongside the existing api blueprints.

### `api/volunteers/volunteers_views.py`
New `GET /api/volunteer/<event_id>/me?type=mentor` endpoint. Frontend uses this to decide interactive vs. read-only rendering of the panel — mirrors the `GET /api/team/<event_id>/me` pattern that `TeamCompletionChecklist` uses.

### `api/leaderboard/leaderboard_service.py` — \"Teams Ready for a Boost\" extension
New `collect_mentor_panel_opportunities()` injects two derived signals into the existing `mentor_opportunities` array consumed by the widget on `/hack/<event_id>#stats`:
- Any team with an **open mentor flag** (cap of 2 per team to limit noise) → card \"🚩 {raiser}: {flag preview}\"
- During the **live event window only** (`start_date <= now <= end_date + 1d`): any team with `mentor_last_touched_at > 4h ago` → card \"👀 No mentor touch in 4h\"

Best-effort: any failure here is logged and ignored so the broader leaderboard never breaks.

### `common/utils/validators.py`
Allows `mentor_slack_channel` as a top-level field on hackathon docs (optional string, ≤80 chars). Falls back to a name-derived guess (`f'{event_id}-mentors'`) at runtime if unset. Admin UI for the field lives in the matching frontend PR.

## New optional Firestore fields on a team doc (no migration; legacy docs stay valid)

\`\`\`
mentor_checklist:  { [slug]: {done, checked_at, checked_by_propel_id,
                               checked_by_name, note?} }
mentor_notes:      [{id, created_at, author_propel_id, author_name,
                     body, deleted_at?, deleted_by_propel_id?}]
mentor_flags:      [{id, created_at, raised_by_propel_id, raised_by_name,
                     severity ('needs_attention'|'blocked'), body,
                     owner_propel_id, owner_name, resolved_at?,
                     resolved_by_propel_id?, resolved_by_name?,
                     resolution_note?}]
mentor_ratings:    [{rated_at, rated_by_propel_id, rated_by_name,
                     criterion ('scope'|'documentation'|'polish'|'security'),
                     score ('green'|'yellow'|'red'), note?}]
mentor_last_touched_at, mentor_last_touched_by_name,
mentor_open_flag_count, mentor_coverage_completed_at,
mentor_coverage_completed_by_name  -- denormalized; the leaderboard
                                       reads these directly
\`\`\`

## Linked Issue
Builds on #226 (project-completion checklist) and #227 (cache/JSON hotfix). Same architectural footprint (per-team Firestore fields, self-serve auth'd endpoints).

## Reviewer notes
- **Identity-field gotcha**: see `user_is_mentor_for_event` — PropelAuth's UUID needs to be translated through `get_propel_user_details_by_id` to match against a volunteers doc's `user_id` (OAuth handle) or `email`. Same pattern as `user_is_on_team`.
- **Frontend depends on** the matching frontend PR (admin UI for `mentor_slack_channel`, the `MentorTeamPanel` component itself). Backend is forward-compatible without it — the fields just stay empty.
- **No data migration needed** — all new team fields are optional.

## Make sure you have
- [x] Pulled from the default branch
- [x] Documented your changes
- [x] Linked the Issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)