### PR TITLE
fix(P0-2): guard None returns from PropelAuth/Slack lookups — eliminate 500s

### DIFF
--- a/api/messages/messages_service.py
+++ b/api/messages/messages_service.py
@@ -81,6 +81,9 @@ if not firebase_admin._apps:
 def save_helping_status_old(propel_user_id, json):
     logger.info(f"save_helping_status {propel_user_id} // {json}")
     slack_user = get_slack_user_from_propel_user_id(propel_user_id)
+    if slack_user is None:
+        logger.warning(f"Could not resolve Slack user for propel_user_id={propel_user_id}")
+        return None
     user_id = slack_user["sub"]
 
     helping_status = json["status"] # helping or not_helping
@@ -257,10 +260,13 @@ def get_single_problem_statement_old(project_id):
     if doc is None:
         logger.warning("get_single_problem_statement end (no results)")
         return {}
-    else:                                
+    else:
         result = doc_to_json(docid=doc.id, doc=doc)
+        if result is None:
+            logger.warning(f"get_single_problem_statement doc_to_json returned None for project_id={project_id}")
+            return {}
         result["id"] = doc.id
-        
+
         logger.info(f"get_single_problem_statement end (with result):{result}")
         return result
     return {}

--- a/api/messages/messages_views.py
+++ b/api/messages/messages_views.py
@@ -721,7 +721,10 @@ def all_profiles():
 def submit_feedback():
     logger.info("POST /feedback called")
     if auth_user and auth_user.user_id:
-        return vars(save_feedback(auth_user.user_id, request.get_json()))
+        result = save_feedback(auth_user.user_id, request.get_json())
+        if result is None:
+            return {"error": "User not found"}, 404
+        return vars(result)
     else:
         return {"error": "Unauthorized"}, 401
     

--- a/api/users/users_views.py
+++ b/api/users/users_views.py
@@ -58,30 +58,35 @@ def get_profile_by_db_id(id):
 
 @bp.route("/volunteering", methods=["POST"])
 @auth.require_user
-def save_volunteering_time():        
-    if auth_user and auth_user.user_id: 
+def save_volunteering_time():
+    if auth_user and auth_user.user_id:
         u: User | None = users_service.save_volunteering_time(auth_user.user_id, request.get_json())
-        return vars(u) if u is not None else None
+        if u is None:
+            return {"error": "User not found or unable to save volunteering time"}, 404
+        return vars(u)
     else:
-        return None
-    
+        return {"error": "Unauthorized"}, 401
+
 
 @bp.route("/volunteering", methods=["GET"])
 @auth.require_user
-def get_volunteering_time():        
+def get_volunteering_time():
     # Get url params
     start_date = request.args.get('startDate')
     end_date = request.args.get('endDate')
-    
+
     if auth_user and auth_user.user_id:
-        allVolunteering, totalActiveHours, totalCommitmentHours = users_service.get_volunteering_time(auth_user.user_id, start_date, end_date)
+        result = users_service.get_volunteering_time(auth_user.user_id, start_date, end_date)
+        if result is None:
+            return {"error": "User not found"}, 404
+        allVolunteering, totalActiveHours, totalCommitmentHours = result
         return {
             "totalActiveHours": totalActiveHours,
             "totalCommitmentHours": totalCommitmentHours,
-            "allVolunteering": allVolunteering            
+            "allVolunteering": allVolunteering
         }
     else:
-        return None
+        return {"error": "Unauthorized"}, 401
     
     
 @bp.route("/admin/volunteering", methods=["GET"])

--- a/services/feedback_service.py
+++ b/services/feedback_service.py
@@ -29,6 +29,9 @@ def save_feedback(propel_user_id, json):
     send_slack_audit(action="save_feedback", message="Saving", payload=json)
 
     slack_user = get_slack_user_from_propel_user_id(propel_user_id)
+    if slack_user is None:
+        logger.warning(f"Could not resolve Slack user for propel_user_id={propel_user_id}")
+        return None
     user_db_id = get_user_from_slack_id(slack_user["sub"]).id
     feedback_giver_id = slack_user["sub"]
 

--- a/services/giveaway_service.py
+++ b/services/giveaway_service.py
@@ -18,6 +18,9 @@ def save_giveaway(propel_user_id, json):
     send_slack_audit(action="submit_giveaway", message="Submitting", payload=json)
 
     slack_user = get_slack_user_from_propel_user_id(propel_user_id)
+    if slack_user is None:
+        logger.warning(f"Could not resolve Slack user for propel_user_id={propel_user_id}")
+        return None
     user_db_id = get_user_from_slack_id(slack_user["sub"]).id
     giveaway_id = json.get("giveaway_id")
     giveaway_data = json.get("giveaway_data", {})
@@ -44,6 +47,9 @@ def get_user_giveaway(propel_user_id):
     db = get_db()
 
     slack_user = get_slack_user_from_propel_user_id(propel_user_id)
+    if slack_user is None:
+        logger.warning(f"Could not resolve Slack user for propel_user_id={propel_user_id}")
+        return {"giveaways": []}
     db_user_id = get_user_from_slack_id(slack_user["sub"]).id
 
     giveaway_docs = db.collection('giveaways').where("user_id", "==", db_user_id).stream()
@@ -64,11 +70,13 @@ def get_all_giveaways():
     giveaways = {}
     for doc in docs:
         giveaway = doc.to_dict()
-        user_id = giveaway["user_id"]
+        user_id = giveaway.get("user_id")
+        if not user_id:
+            continue
         if user_id not in giveaways:
             from api.messages.messages_service import get_user_by_id_old
             user = get_user_by_id_old(user_id)
-            giveaway["user"] = user
+            giveaway["user"] = user if user is not None else {}
             giveaways[user_id] = giveaway
 
     return {"giveaways": list(giveaways.values())}

--- a/services/hackathons_service.py
+++ b/services/hackathons_service.py
@@ -714,9 +714,12 @@ def update_hackathon_volunteers(event_id, volunteer_type, json, propel_id):
 
     doc_ref.update(json)
 
-    slack_user_id = doc.get('slack_user_id')
+    slack_user_id = doc.to_dict().get('slack_user_id') if doc_dict else None
 
-    hackathon_welcome_message = f"🎉 Welcome <@{slack_user_id}> [{doc_volunteer_type}]."
+    if not slack_user_id:
+        logger.warning(f"Volunteer {volunteer_id} has no slack_user_id; skipping Slack welcome message")
+
+    hackathon_welcome_message = f"🎉 Welcome <@{slack_user_id}> [{doc_volunteer_type}]." if slack_user_id else None
 
     base_message = f"🎉 Welcome to Opportunity Hack {event_id}! You're checked in as a {doc_volunteer_type}.\n\n"
 
@@ -759,20 +762,23 @@ def update_hackathon_volunteers(event_id, volunteer_type, json, propel_id):
 """
 
     if json.get("checkedIn") is True and "checkedIn" not in doc_dict.keys() and doc_dict.get("checkedIn") != True:
-        logger.info(f"Volunteer {volunteer_id} just checked in, sending welcome message to {slack_user_id}")
-        invite_user_to_channel(slack_user_id, "hackathon-welcome")
+        if slack_user_id:
+            logger.info(f"Volunteer {volunteer_id} just checked in, sending welcome message to {slack_user_id}")
+            invite_user_to_channel(slack_user_id, "hackathon-welcome")
 
-        logger.info(f"Sending Slack message to volunteer {volunteer_id} in channel #{slack_user_id} and #hackathon-welcome")
-        async_send_slack(
-            channel="#hackathon-welcome",
-            message=hackathon_welcome_message
-        )
+            logger.info(f"Sending Slack message to volunteer {volunteer_id} in channel #{slack_user_id} and #hackathon-welcome")
+            async_send_slack(
+                channel="#hackathon-welcome",
+                message=hackathon_welcome_message
+            )
 
-        logger.info(f"Sending Slack DM to volunteer {volunteer_id} in channel #{slack_user_id}")
-        async_send_slack(
-            channel=slack_user_id,
-            message=slack_message_content
-        )
+            logger.info(f"Sending Slack DM to volunteer {volunteer_id} in channel #{slack_user_id}")
+            async_send_slack(
+                channel=slack_user_id,
+                message=slack_message_content
+            )
+        else:
+            logger.warning(f"Volunteer {volunteer_id} checked in but no slack_user_id — skipping Slack welcome")
     else:
         logger.info(f"Volunteer {volunteer_id} checked in again, no welcome message sent.")
 

--- a/services/users_service.py
+++ b/services/users_service.py
@@ -313,6 +313,10 @@ def get_profile_metadata(propel_id):
             propel_id=propel_id
             )
 
+    if db_id is None:
+        warning(logger, "save_user returned None — PropelAuth provided empty values", propel_id=propel_id)
+        return None
+
     # Get all of the user history and profile data from the DB
     response = get_history(db_id.id)
     logger.debug(f"get_profile_metadata {response}")
@@ -433,7 +437,7 @@ def get_volunteering_time(propel_id, start_date, end_date):
     logger.info(f"Get Volunteering Time for {propel_id} {start_date} {end_date}")
     oauth_user = get_oauth_user_from_propel_user_id(propel_id)
     if oauth_user is None:
-        error(logger, "Could not get OAuth user from PropelAuth", propel_id=propel_id)
+        warning(logger, "Could not get OAuth user from PropelAuth", propel_id=propel_id)
         return None
 
     user_id = oauth_user["sub"]
@@ -443,7 +447,8 @@ def get_volunteering_time(propel_id, start_date, end_date):
     # Get the user
     user = fetch_user_by_user_id(user_id)
     if user is None:
-        return
+        warning(logger, "User not found", user_id=user_id)
+        return None
 
     # Filter the volunteering data
     volunteeringActiveTime = []


### PR DESCRIPTION
## Summary

Fixes 6 crash patterns surfaced in Sentry (134 + 21 + 11 + 10 + 6 + 3 events) — all share the same root cause: \`get_slack_user_from_propel_user_id()\` or \`get_oauth_user_from_propel_user_id()\` can return \`None\` and callers immediately subscript it without a guard.

## Changes

| File | Fix |
|------|-----|
| \`services/feedback_service.py\` | Guard \`slack_user is None\` in \`save_feedback\`; view returns 404 instead of crashing |
| \`services/giveaway_service.py\` | Guard \`slack_user is None\` in \`save_giveaway\` + \`get_user_giveaway\`; guard \`user is None\` in \`get_all_giveaways\` |
| \`api/messages/messages_service.py\` | Guard \`slack_user is None\` in \`save_helping_status_old\`; guard \`doc_to_json\` None return in \`get_single_problem_statement_old\` (in-place per frozen-file rule) |
| \`api/messages/messages_views.py\` | \`submit_feedback\` returns 404 on None result (in-place fix) |
| \`api/users/users_views.py\` | \`save_volunteering_time\` returns 404 on None; \`get_volunteering_time\` guards tuple unpack |
| \`services/users_service.py\` | \`get_profile_metadata\`: guard \`db_id is None\` after \`save_user()\`; \`get_volunteering_time\`: return None explicitly with warning log |
| \`services/hackathons_service.py\` | \`update_*_by_event_id\`: use \`doc.to_dict().get('slack_user_id')\` (fixes KeyError); gate all Slack calls on non-None \`slack_user_id\` so update still succeeds and returns 200 |

## Test plan
- [ ] POST /api/messages/feedback with an unknown propel_id → 404, not 500
- [ ] GET /api/users/volunteering with an unknown propel_id → 404, not 500
- [ ] Check-in a volunteer with no slack_user_id → update succeeds, no Slack error in logs