### PR TITLE
[Perf] P1-3, P2-1, P2-2, P2-7: PropelAuth cache, NPO batch read, Slack hardening, log sweep

### DIFF
--- a/api/judging/judging_service.py
+++ b/api/judging/judging_service.py
@@ -717,7 +717,7 @@ def get_judge_event_details(judge_id: str, event_id: str) -> Dict:
         user_id=judge_id, volunteer_type="judge", event_id=event_id
     )
     if not volunteer:
-        logger.error(f"Judge not found for user_id {judge_id} and event_id {event_id}")
+        logger.info(f"Judge not found for user_id {judge_id} and event_id {event_id}")
         return {"error": "Judge not found"}, 404
 
     logger.debug(f"Fetched judge details: {volunteer}")

--- a/api/messages/messages_service.py
+++ b/api/messages/messages_service.py
@@ -619,7 +619,7 @@ def get_user_by_id_old(id):
         return res
 
     except NotFound:
-        logger.error(f"Document with ID {id} not found in 'users' collection")
+        logger.info(f"Document with ID {id} not found in 'users' collection")
         return {}
     except Exception as e:
         logger.error(f"Error retrieving user data for ID {id}: {str(e)}")

--- a/common/utils/slack.py
+++ b/common/utils/slack.py
@@ -127,19 +127,37 @@ def get_client():
     client = WebClient(token=token)
     return client
 
+_EMAIL_USER_CACHE = TTLCache(maxsize=500, ttl=86400)  # 24h — email→user rarely changes
+_EMAIL_USER_MISS_CACHE = TTLCache(maxsize=500, ttl=3600)  # 1h negative cache
+_EMAIL_USER_LOCK = threading.Lock()
+
+
+@sleep_and_retry
+@limits(calls=20, period=60)
 def get_slack_user_by_email(email):
     """
-    Get Slack user by email address.
-    
-    :param email: Email address of the user
-    :return: User information if found, None otherwise
+    Get Slack user by email address. Cached 24h (hits) / 1h (misses).
+    users.lookupByEmail is tightly rate-limited — cache aggressively.
     """
+    if not email:
+        return None
+    with _EMAIL_USER_LOCK:
+        if email in _EMAIL_USER_MISS_CACHE:
+            return None
+        if email in _EMAIL_USER_CACHE:
+            return _EMAIL_USER_CACHE[email]
+
     client = get_client()
     try:
         result = client.users_lookupByEmail(email=email)
-        return result["user"]
+        user = result["user"]
+        with _EMAIL_USER_LOCK:
+            _EMAIL_USER_CACHE[email] = user
+        return user
     except SlackApiError as e:
-        logger.error(f"Error fetching user by email {email}: {e}")
+        logger.warning(f"Could not look up Slack user by email {email}: {e}")
+        with _EMAIL_USER_LOCK:
+            _EMAIL_USER_MISS_CACHE[email] = True
         return None
 
 
@@ -196,8 +214,8 @@ def is_channel_id(channel_id):
         result = client.conversations_info(channel=channel_id)
         return True
     except SlackApiError as e:
-        logger.error(f"Error checking channel ID {channel_id}: {e}")
-        return False    
+        logger.debug(f"is_channel_id: conversations.info failed for {channel_id}: {e}")
+        return False
 
 
 def add_bot_to_channel(channel_id):
@@ -336,8 +354,7 @@ def send_slack(message="", channel="", icon_emoji=None, username="Hackathon Bot"
         
         response = client.chat_postMessage(**kwargs)
     except SlackApiError as e:
-        logger.error(e.response["error"])
-        assert e.response["error"]
+        logger.warning(f"send_slack failed for channel={channel_id}: {e.response.get('error', e)}")
 
 
 def async_send_slack(message="", channel="", icon_emoji=None, username="Hackathon Bot", blocks=None):

--- a/services/nonprofits_service.py
+++ b/services/nonprofits_service.py
@@ -151,15 +151,22 @@ def get_npos_by_hackathon_id(id):
             npo_refs = doc_dict["nonprofits"]
             logger.info(f"get_npos_by_hackathon_id found {len(npo_refs)} nonprofit references")
 
-            for npo_ref in npo_refs:
-                try:
-                    npo_doc = npo_ref.get()
+            try:
+                npo_snaps = list(db.get_all(npo_refs))
+                for npo_doc in npo_snaps:
                     if npo_doc.exists:
                         npo = doc_to_json(docid=npo_doc.id, doc=npo_doc)
                         npos.append(npo)
-                except Exception as e:
-                    logger.error(f"Error processing nonprofit reference: {e}")
-                    continue
+            except Exception as e:
+                logger.warning(f"get_npos_by_hackathon_id batch read failed, falling back: {e}")
+                for npo_ref in npo_refs:
+                    try:
+                        npo_doc = npo_ref.get()
+                        if npo_doc.exists:
+                            npos.append(doc_to_json(docid=npo_doc.id, doc=npo_doc))
+                    except Exception as inner_e:
+                        logger.warning(f"Error processing nonprofit reference: {inner_e}")
+                        continue
 
         return {
             "nonprofits": npos

--- a/services/teams_service.py
+++ b/services/teams_service.py
@@ -410,14 +410,14 @@ def join_team(propel_user_id, json):
 
     slack_user = get_slack_user_from_propel_user_id(propel_user_id)
     if not slack_user or "sub" not in slack_user:
-        logger.error(f"Could not resolve Slack user for propel_user_id={propel_user_id}")
+        logger.warning(f"Could not resolve Slack user for propel_user_id={propel_user_id}")
         return Message("Error: User not found")
 
     slack_user_id = slack_user["sub"]
     slack_member_id = extract_slack_user_id(slack_user_id)
     user = get_user_from_slack_id(slack_user_id)
     if user is None:
-        logger.error(f"Could not resolve database user for slack_user_id={slack_user_id}")
+        logger.warning(f"Could not resolve database user for slack_user_id={slack_user_id}")
         return Message("Error: User not found")
 
     userid = user.id
@@ -484,14 +484,14 @@ def unjoin_team(propel_user_id, json):
 
     slack_user = get_slack_user_from_propel_user_id(propel_user_id)
     if not slack_user or "sub" not in slack_user:
-        logger.error(f"Could not resolve Slack user for propel_user_id={propel_user_id}")
+        logger.warning(f"Could not resolve Slack user for propel_user_id={propel_user_id}")
         return Message("Error: User not found")
 
     slack_user_id = slack_user["sub"]
     slack_member_id = extract_slack_user_id(slack_user_id)
     user = get_user_from_slack_id(slack_user_id)
     if user is None:
-        logger.error(f"Could not resolve database user for slack_user_id={slack_user_id}")
+        logger.warning(f"Could not resolve database user for slack_user_id={slack_user_id}")
         return Message("Error: User not found")
 
     userid = user.id

--- a/services/users_service.py
+++ b/services/users_service.py
@@ -170,19 +170,27 @@ def get_user_from_propel_user_id(propel_id):
     return get_user_from_slack_id(user_id)
 
 
+# Two-tier PropelAuth cache: positive results (10 min) + negative sentinel (5 min).
+# Intentionally in-process only — the payload contains OAuth access tokens.
+_PROPEL_CACHE = TTLCache(maxsize=512, ttl=600)
+_PROPEL_MISS_CACHE = TTLCache(maxsize=512, ttl=300)
+_PROPEL_LOCK = threading.Lock()
+_PROPEL_MISS = object()  # sentinel so we can cache None explicitly
+
+
 def get_oauth_user_from_propel_user_id(propel_id):
     """
     Get user details from any OAuth provider via PropelAuth.
 
-    This function detects which OAuth provider (Slack, Google, etc.) was used
-    and fetches user details from the appropriate provider's API.
-
-    Args:
-        propel_id: The PropelAuth user ID
-
-    Returns:
-        dict: User details with normalized fields including 'sub' (user ID)
+    Cached in-process (10 min hit / 5 min miss) — do NOT put in Redis since
+    the response contains OAuth access tokens.
     """
+    with _PROPEL_LOCK:
+        if propel_id in _PROPEL_MISS_CACHE:
+            return None
+        if propel_id in _PROPEL_CACHE:
+            return _PROPEL_CACHE[propel_id]
+
     url = f"{os.getenv('PROPEL_AUTH_URL')}/api/backend/v1/user/{propel_id}/oauth_token"
 
     debug(logger, "Propel API URL", url=url)
@@ -195,6 +203,8 @@ def get_oauth_user_from_propel_user_id(propel_id):
     if resp.status_code != 200:
         warning(logger, "PropelAuth API returned non-200",
                 status=resp.status_code, propel_id=propel_id)
+        with _PROPEL_LOCK:
+            _PROPEL_MISS_CACHE[propel_id] = _PROPEL_MISS
         return None
     json_resp = resp.json()
     logger.debug(f"Propel RESP JSON: {json_resp}")
@@ -204,23 +214,34 @@ def get_oauth_user_from_propel_user_id(propel_id):
 
     if provider is None or token_data is None:
         warning(logger, "Could not detect OAuth provider from PropelAuth response", response=json_resp)
+        with _PROPEL_LOCK:
+            _PROPEL_MISS_CACHE[propel_id] = _PROPEL_MISS
         return None
 
     access_token = token_data.get('access_token')
     if not access_token:
         warning(logger, "No access token found in PropelAuth response", provider=provider, response=json_resp)
+        with _PROPEL_LOCK:
+            _PROPEL_MISS_CACHE[propel_id] = _PROPEL_MISS
         return None
 
     debug(logger, "Detected OAuth provider", provider=provider)
 
     # Fetch user details from the appropriate provider
     if provider == 'slack':
-        return get_slack_user_from_token(access_token)
+        result = get_slack_user_from_token(access_token)
     elif provider == 'google':
-        return get_google_user_from_token(access_token)
+        result = get_google_user_from_token(access_token)
     else:
         warning(logger, "Unsupported OAuth provider", provider=provider)
-        return None
+        result = None
+
+    with _PROPEL_LOCK:
+        if result is not None:
+            _PROPEL_CACHE[propel_id] = result
+        else:
+            _PROPEL_MISS_CACHE[propel_id] = _PROPEL_MISS
+    return result
 
 
 def get_slack_user_from_propel_user_id(propel_id):
@@ -335,7 +356,7 @@ def save_profile_metadata(propel_id, json):
 
     oauth_user = get_oauth_user_from_propel_user_id(propel_id)
     if oauth_user is None:
-        error(logger, "Could not get OAuth user from PropelAuth", propel_id=propel_id)
+        warning(logger, "Could not get OAuth user from PropelAuth", propel_id=propel_id)
         return None
 
     user_id = oauth_user["sub"]
@@ -378,7 +399,7 @@ def save_volunteering_time(propel_id, json):
     logger.info(f"Save Volunteering Time for {propel_id} {json}")
     oauth_user = get_oauth_user_from_propel_user_id(propel_id)
     if oauth_user is None:
-        error(logger, "Could not get OAuth user from PropelAuth", propel_id=propel_id)
+        warning(logger, "Could not get OAuth user from PropelAuth", propel_id=propel_id)
         return None
 
     user_id = oauth_user["sub"]
@@ -388,7 +409,7 @@ def save_volunteering_time(propel_id, json):
     # Get the user
     user = fetch_user_by_user_id(user_id)
     if user is None:
-        error(logger, "User not found", user_id=user_id)
+        warning(logger, "User not found", user_id=user_id)
         return
 
     timestamp = datetime.now().isoformat() + "Z"
@@ -434,7 +455,7 @@ def get_volunteering_time(propel_id, start_date, end_date):
     logger.info(f"Get Volunteering Time for {propel_id} {start_date} {end_date}")
     oauth_user = get_oauth_user_from_propel_user_id(propel_id)
     if oauth_user is None:
-        error(logger, "Could not get OAuth user from PropelAuth", propel_id=propel_id)
+        warning(logger, "Could not get OAuth user from PropelAuth", propel_id=propel_id)
         return None
 
     user_id = oauth_user["sub"]
@@ -540,7 +561,7 @@ def get_privacy_settings(propel_id):
     logger.info(f"Get Privacy Settings for {propel_id}")
     oauth_user = get_oauth_user_from_propel_user_id(propel_id)
     if oauth_user is None:
-        error(logger, "Could not get OAuth user from PropelAuth", propel_id=propel_id)
+        warning(logger, "Could not get OAuth user from PropelAuth", propel_id=propel_id)
         return None
 
     user_id = oauth_user["sub"]
@@ -548,7 +569,7 @@ def get_privacy_settings(propel_id):
     # Get the user
     user = fetch_user_by_user_id(user_id)
     if user is None:
-        error(logger, "User not found", user_id=user_id)
+        warning(logger, "User not found", user_id=user_id)
         return None
 
     return user.get_privacy_settings()
@@ -559,7 +580,7 @@ def update_privacy_settings(propel_id, data):
     logger.info(f"Update Privacy Settings for {propel_id} {data}")
     oauth_user = get_oauth_user_from_propel_user_id(propel_id)
     if oauth_user is None:
-        error(logger, "Could not get OAuth user from PropelAuth", propel_id=propel_id)
+        warning(logger, "Could not get OAuth user from PropelAuth", propel_id=propel_id)
         return None
 
     user_id = oauth_user["sub"]
@@ -567,7 +588,7 @@ def update_privacy_settings(propel_id, data):
     # Get the user
     user = fetch_user_by_user_id(user_id)
     if user is None:
-        error(logger, "User not found", user_id=user_id)
+        warning(logger, "User not found", user_id=user_id)
         return None
 
     # Update the privacy settings

--- a/services/volunteers_service.py
+++ b/services/volunteers_service.py
@@ -466,18 +466,40 @@ def send_slack_volunteer_notification(volunteer_data: Dict[str, Any], is_update:
 
     available_days = volunteer_data.get('availableDays', '')
     if available_days:
-        detail_lines.append(f"*Available Days:* {available_days}")
+        days_str = str(available_days)
+        if len(days_str) > 500:
+            days_str = days_str[:497] + "…"
+        detail_lines.append(f"*Available Days:* {days_str}")
 
     skills = volunteer_data.get('skills', '')
     if skills:
-        detail_lines.append(f"*Skills:* {skills}")
+        skills_str = str(skills)[:500] if len(str(skills)) > 500 else str(skills)
+        detail_lines.append(f"*Skills:* {skills_str}")
 
     experience = volunteer_data.get('experience', '')
     if experience:
-        detail_lines.append(f"*Experience:* {experience}")
+        exp_str = str(experience)[:500] if len(str(experience)) > 500 else str(experience)
+        detail_lines.append(f"*Experience:* {exp_str}")
 
     if detail_lines:
-        blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "\n".join(detail_lines)}})
+        # Slack section text cap is 3000 chars; split if needed (max 50 blocks total).
+        section_text = "\n".join(detail_lines)
+        if len(section_text) <= 2900:
+            blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": section_text}})
+        else:
+            # Split into ≤2900-char chunks
+            chunk, chunks = [], []
+            for line in detail_lines:
+                candidate = "\n".join(chunk + [line])
+                if len(candidate) > 2900 and chunk:
+                    chunks.append("\n".join(chunk))
+                    chunk = [line]
+                else:
+                    chunk.append(line)
+            if chunk:
+                chunks.append("\n".join(chunk))
+            for c in chunks[:48]:  # leave room for header + footer blocks
+                blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": c}})
 
     # Context footer — timestamp + Slack workspace lookup result
     context_elements = [


### PR DESCRIPTION
## Summary

- **P1-3 PropelAuth cache** (`users_service.py`): Two-tier in-process TTLCache (10-min positive / 5-min negative). Eliminates repeated HTTP calls to PropelAuth+Slack/Google for the same user across a request storm. Expected p50 improvement: `get_privacy_settings` 328ms → <50ms warm; `get_my_volunteer_status_for_event` 611ms → <200ms. **Not Redis** — payload contains OAuth access tokens.

- **P2-1 NPO N+1** (`nonprofits_service.py`): `get_npos_by_hackathon_id` replaced per-ref sequential `.get()` loop with single `db.get_all(npo_refs)` batch read. Expected: p50 171ms → <80ms.

- **P2-2 Slack hardening**:
  - `get_slack_user_by_email`: Added 24h/1h two-tier cache + `@sleep_and_retry` + `@limits(20/min)` — was causing 28 Sentry failures from tight rate-limiting.
  - `send_slack`: Replaced `assert e.response["error"]` (raised out of business logic!) with `logger.warning` — a Slack failure must never fail a user-facing request.
  - `is_channel_id`: Downgraded error → debug; fallback to name lookup is the designed code path.
  - `volunteers_service`: Truncate per-field strings to ≤500 chars; split section block if >2900 chars — fixes `invalid_blocks` Sentry issue on `update_mentor_application`.

- **P2-7 log sweep**: Downgraded ~10 `error`/`logger.error` calls to `warning`/`info` for expected-absence 404 paths across teams, users, judging, and messages services.

## Test plan

- [ ] Login/profile load: check PropelAuth call count in logs — second request for same user should show no PropelAuth HTTP call
- [ ] `GET /api/messages/npos/hackathon/{id}` for an event with 5+ NPOs: should complete in <80ms
- [ ] Application submit for a user with unknown email: no Slack rate-limit errors, no Sentry `SlackApiError`
- [ ] Long mentor application (`availableDays` field >500 chars): should post without `invalid_blocks` Sentry error
- [ ] Sentry error feed: "Could not get OAuth user from PropelAuth", "Could not resolve Slack user", "Judge not found" entries should become warnings, not errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)