### PR TITLE
[Volunteer Admin] Enrich admin records with user_db_id and profile_image

### DIFF
--- a/common/utils/firebase.py
+++ b/common/utils/firebase.py
@@ -1354,6 +1354,9 @@ def get_volunteer_from_db_by_event(event_id: str, volunteer_type: str, admin: bo
                     user = user_map[email]
                     if "history" in user and "certificates" in user["history"]:
                         volunteer["certificates"] = user["history"]["certificates"]
+                    volunteer["user_db_id"] = user["id"]
+                    if user.get("profile_image"):
+                        volunteer["profile_image"] = user["profile_image"]
 
         return {"data": volunteers}
 


### PR DESCRIPTION
## Summary
- In `common/utils/firebase.py`, the existing admin-mode volunteer enrichment loop (which already does a batch `get_users_by_emails` for certificate lookup) now also sets:
  - `user_db_id` = Firestore users doc id → used by frontend to link `/profile/{id}`
  - `profile_image` = avatar URL (optional)
- Zero new Firestore reads; reuses the existing `user_map`
- Admin-gated endpoint only (`admin=True` branch); new keys are ignored by non-admin consumers

Companion frontend PR: `feat/volunteer-admin-improvements` on frontend-ohack.dev.

## Test plan
- [ ] Call `GET /api/messages/admin/hackathon/{event_id}/mentor` (or judge/volunteer/hacker) with admin token → each record that has a matching users doc now carries `user_db_id` and `profile_image`
- [ ] Records without a matching user doc remain unaffected
- [ ] Public (non-admin) volunteer endpoint unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)